### PR TITLE
Add Conda links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ with more modern tooling applied elsewhere.
 
 [hypermodern python cookiecutter]: https://github.com/cjolowicz/cookiecutter-hypermodern-python
 [pypi]: https://pypi.org/
+[conda-forge]: https://conda-forge.org/
 [file an issue]: https://github.com/TGSAI/segy/issues
 [pip]: https://pip.pypa.io/
+[conda]: https://docs.conda.io/
 
 <!-- github-only -->
 


### PR DESCRIPTION
Include links to the Conda-Forge and Conda documentation in the README to provide users with additional resources for package installation and management.