### PR TITLE
Adjust module doctoring whitespaces

### DIFF
--- a/src/segy/cli/common.py
+++ b/src/segy/cli/common.py
@@ -1,6 +1,5 @@
 """Common components for the CLI."""
 
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/segy/schema/__init__.py
+++ b/src/segy/schema/__init__.py
@@ -1,6 +1,5 @@
 """Data models for manipulating all kinds of SEG-Y files."""
 
-
 from segy.schema.data_type import Endianness
 from segy.schema.data_type import ScalarType
 from segy.schema.data_type import StructuredDataTypeDescriptor

--- a/src/segy/schema/base.py
+++ b/src/segy/schema/base.py
@@ -1,4 +1,5 @@
 """Core functionality for SEG-Y ninja templates."""
+
 from __future__ import annotations
 
 from abc import abstractmethod

--- a/src/segy/schema/trace.py
+++ b/src/segy/schema/trace.py
@@ -1,4 +1,5 @@
 """Descriptor data model implementations for traces."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/segy/standards/__init__.py
+++ b/src/segy/standards/__init__.py
@@ -1,6 +1,5 @@
 """Implementation of SEG-Y standards."""
 
-
 from segy.schema import SegyStandard
 from segy.standards.registry import register_spec
 from segy.standards.rev0 import rev0_segy

--- a/src/segy/standards/registry.py
+++ b/src/segy/standards/registry.py
@@ -1,4 +1,5 @@
 """Implements a registry for various SEG-Y standards."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 This is very janky, we need to find a better way to do this.
 """
 
-
 from __future__ import annotations
 
 import string

--- a/tests/main/test_ibm_ieee.py
+++ b/tests/main/test_ibm_ieee.py
@@ -1,4 +1,5 @@
 """tests for data types defined for SegyFile components."""
+
 import numpy as np
 import pytest
 

--- a/tests/main/test_ibm_ieee.py
+++ b/tests/main/test_ibm_ieee.py
@@ -1,4 +1,4 @@
-"""tests for data types defined for SegyFile components."""
+"""Tests for data types defined for SegyFile components."""
 
 import numpy as np
 import pytest

--- a/tests/main/test_indexing.py
+++ b/tests/main/test_indexing.py
@@ -1,6 +1,5 @@
 """Tests for functions in indexing."""
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/schema/test_data_type.py
+++ b/tests/schema/test_data_type.py
@@ -1,6 +1,5 @@
 """Tests for components that define fields and data types of a SEGY Schema."""
 
-
 from __future__ import annotations
 
 import string

--- a/tests/schema/test_header.py
+++ b/tests/schema/test_header.py
@@ -1,6 +1,5 @@
 """Tests for the Text Headers, Binary Headers, and Trace Headers for different SEGY revisions."""
 
-
 from __future__ import annotations
 
 import operator

--- a/tests/schema/test_segy_descriptor.py
+++ b/tests/schema/test_segy_descriptor.py
@@ -1,4 +1,4 @@
-"""tests for SegyDescriptor components."""
+"""Tests for SegyDescriptor components."""
 
 from typing import Any
 

--- a/tests/schema/test_segy_descriptor.py
+++ b/tests/schema/test_segy_descriptor.py
@@ -1,4 +1,5 @@
 """tests for SegyDescriptor components."""
+
 from typing import Any
 
 import pytest

--- a/tests/standards/test_registry.py
+++ b/tests/standards/test_registry.py
@@ -1,4 +1,5 @@
 """tests for functions in segy.schema.registry."""
+
 import pytest
 
 from segy.schema import SegyDescriptor

--- a/tests/standards/test_registry.py
+++ b/tests/standards/test_registry.py
@@ -1,4 +1,4 @@
-"""tests for functions in segy.schema.registry."""
+"""Tests for functions in segy.schema.registry."""
 
 import pytest
 


### PR DESCRIPTION
Several files have been updated to improve their readability by adjusting the whitespace. This includes mostly adding an empty line after the initial comment line, or removing an unnecessary empty line. The changes have been applied both to source and test files.