### PR TITLE
Support for handling IBM float trace headers

### DIFF
--- a/src/segy/file.py
+++ b/src/segy/file.py
@@ -218,8 +218,14 @@ class SegyFile:
     @property
     def header(self) -> HeaderIndexer:
         """Way to access the file to fetch trace headers only."""
+        ibm_header_keys = [
+            field.name
+            for field in self.spec.trace.header_descriptor.fields
+            if field.dtype == ScalarType.IBM32
+        ]
         transforms = [
             TransformFactory.create("byte_swap", Endianness.LITTLE),
+            TransformFactory.create("ibm_float", "to_ieee", keys=ibm_header_keys),
         ]
 
         return HeaderIndexer(


### PR DESCRIPTION
Added a check for fields that are of type Ibm32 in the HeaderIndexer. Included another case in test for test_transforms.py.