### PR TITLE
Fix broken CI: Make CI tooling constraint paths absolute

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
+          pip install -c "${{ github.workspace }}/.github/workflows/constraints.txt" pip
           pip --version
 
       - name: Upgrade pip in virtual environments
@@ -63,13 +63,13 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints-poetry.txt poetry
+          pipx install --pip-args="-c ${{ github.workspace }}/.github/workflows/constraints-poetry.txt" poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args="-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
+          pipx inject --pip-args="-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
 
       - name: Compute pre-commit cache key
@@ -128,18 +128,18 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
+          pip install -c "${{ github.workspace }}/.github/workflows/constraints.txt" pip
           pip --version
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints-poetry.txt poetry
+          pipx install --pip-args="-c ${{ github.workspace }}/.github/workflows/constraints-poetry.txt" poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args="-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
+          pipx inject --pip-args="-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
 
       - name: Download coverage data


### PR DESCRIPTION
CI was breaking with the latest runners, so changed to absolute paths.