### PR TITLE
Override Numpy's copy method to `SegyArray` to ensure uninterpreted bytes are preserved.

### DIFF
--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -18,7 +18,11 @@ import numpy as np
 from pandas import DataFrame
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from numpy.typing import NDArray
+
+    OrderKACF = Literal["K", "A", "C", "F"]
 
 
 class SegyArray(np.ndarray):  # type: ignore[type-arg]
@@ -32,6 +36,16 @@ class SegyArray(np.ndarray):  # type: ignore[type-arg]
         """Numpy subclass logic."""
         if obj is None:
             return
+
+    def copy(self, order: OrderKACF = "K") -> TraceArray:
+        """Copy structured array preserving the padded bytes as is.
+
+        This method ensures that the copy includes raw binary data and any padding
+        bytes, preserving the entire memory layout of the array. This is necessary
+        for working with SEG-Y data where not all fields are parsed, but raw binary
+        data preservation is crucial.
+        """
+        return np.copy(self.view("V"), order=order, subok=True).view(self.dtype)
 
 
 class HeaderArray(SegyArray):

--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -46,8 +46,8 @@ class SegyArray(np.ndarray):  # type: ignore[type-arg]
         data preservation is crucial.
         """
         void_view = self.view("V")
-        final_copy = np.copy(void_view, order=order, subok=True).view(self.dtype)
-        return final_copy.view(type(self))  # Ensure return type is SegyArray
+        void_copy = np.copy(void_view, order=order, subok=True)
+        return void_copy.view(self.dtype)  # type: ignore[no-any-return]
 
 
 class HeaderArray(SegyArray):

--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -46,9 +46,8 @@ class SegyArray(np.ndarray):  # type: ignore[type-arg]
         data preservation is crucial.
         """
         void_view = self.view("V")
-        void_view_copy = np.copy(void_view, order=order, subok=True)
-        copy_with_dtype = void_view_copy.astype(self.dtype)
-        return copy_with_dtype.view(type(self))  # Ensure type is SegyArray
+        final_copy = np.copy(void_view, order=order, subok=True).view(self.dtype)
+        return final_copy.view(type(self))  # Ensure return type is SegyArray
 
 
 class HeaderArray(SegyArray):

--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    OrderKACF = Literal["K", "A", "C", "F"]
+    OrderKACF = Literal[None, "K", "A", "C", "F"]
 
 
 class SegyArray(np.ndarray):  # type: ignore[type-arg]
@@ -37,7 +37,7 @@ class SegyArray(np.ndarray):  # type: ignore[type-arg]
         if obj is None:
             return
 
-    def copy(self, order: OrderKACF = "K") -> TraceArray:
+    def copy(self, order: OrderKACF = "K") -> SegyArray:
         """Copy structured array preserving the padded bytes as is.
 
         This method ensures that the copy includes raw binary data and any padding
@@ -45,7 +45,10 @@ class SegyArray(np.ndarray):  # type: ignore[type-arg]
         for working with SEG-Y data where not all fields are parsed, but raw binary
         data preservation is crucial.
         """
-        return np.copy(self.view("V"), order=order, subok=True).view(self.dtype)
+        void_view = self.view("V")
+        void_view_copy = np.copy(void_view, order=order, subok=True)
+        copy_with_dtype = void_view_copy.astype(self.dtype)
+        return copy_with_dtype.view(type(self))  # Ensure type is SegyArray
 
 
 class HeaderArray(SegyArray):

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -1,0 +1,24 @@
+"""Test Numpy array subclasses."""
+
+import numpy as np
+
+from segy.arrays import SegyArray
+
+
+def test_segy_array_copy() -> None:
+    """Test copying a segy array with exact underlying buffer."""
+    buffer_expected = np.asarray([0, 1, 2, 3, 4], dtype="uint16").tobytes()
+
+    dtype = np.dtype(
+        {
+            "names": ["f1", "f2"],
+            "offsets": [0, 4],
+            "formats": ["uint16", "uint16"],
+            "itemsize": 10,
+        }
+    )
+    segy_array = SegyArray(np.frombuffer(buffer_expected, dtype=dtype))
+    segy_array_copy = segy_array.copy()
+
+    assert segy_array_copy.tobytes() == buffer_expected
+    assert np.may_share_memory(segy_array_copy, segy_array) is False


### PR DESCRIPTION
A `copy` method, which maintains raw binary data and padding bytes, has been added to the `SegyArray`. This is essential for SEG-Y data processing where unparsed fields are present and preserving raw (uninterpreted) binary data integrity is crucial.