### PR TITLE
Make fetched raw bytes mutable for downstream transforms

### DIFF
--- a/src/segy/indexing.py
+++ b/src/segy/indexing.py
@@ -32,7 +32,7 @@ def merge_cat_file(
     starts: list[int],
     ends: list[int],
     block_size: int = 8_388_608,
-) -> bytes:
+) -> bytearray:
     """Merge sequential byte start/ends and fetch from store.
 
     Args:
@@ -62,7 +62,7 @@ def merge_cat_file(
         ends=ends,
     )
 
-    return b"".join(buffer_bytes)
+    return bytearray(b"".join(buffer_bytes))
 
 
 def bounds_check(indices: list[int], max_: int, type_: str) -> None:
@@ -137,7 +137,7 @@ class AbstractIndexer(ABC):
         """Logic to calculate start/end bytes."""
 
     @abstractmethod
-    def decode(self, buffer: bytes) -> NDArray[Any]:
+    def decode(self, buffer: bytearray) -> NDArray[Any]:
         """How to decode the bytes after reading."""
 
     def post_process(self, data: NDArray[Any]) -> NDArray[Any]:
@@ -219,7 +219,7 @@ class TraceIndexer(AbstractIndexer):
 
         return starts, ends
 
-    def decode(self, buffer: bytes) -> TraceArray:
+    def decode(self, buffer: bytearray) -> TraceArray:
         """Decode whole traces (header + data)."""
         data = np.frombuffer(buffer, dtype=self.spec.dtype)
         return TraceArray(data)
@@ -251,7 +251,7 @@ class HeaderIndexer(AbstractIndexer):
 
         return starts, ends
 
-    def decode(self, buffer: bytes) -> HeaderArray:
+    def decode(self, buffer: bytearray) -> HeaderArray:
         """Decode headers only."""
         data = np.frombuffer(buffer, dtype=self.spec.dtype["header"])
         return HeaderArray(data)
@@ -283,6 +283,6 @@ class SampleIndexer(AbstractIndexer):
 
         return starts, ends
 
-    def decode(self, buffer: bytes) -> NDArray[Any]:
+    def decode(self, buffer: bytearray) -> NDArray[Any]:
         """Decode trace samples only."""
         return np.frombuffer(buffer, dtype=self.spec.dtype["sample"])


### PR DESCRIPTION
For memory efficiency, we are going to make transforms apply in-place. This would require the underlying memory to be mutable. The original `bytes` are immutable, so we convert them to `bytearray` on the spot. 