### PR TITLE
Make transforms in-place and remove unnecessary transforms to simplify logic

### DIFF
--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -163,27 +163,6 @@ class Transform:
         return data
 
 
-class ScaleTransform(Transform):
-    """Scales numeric data by a specified factor.
-
-    Args:
-        scalar: Scalar to apply to the data.
-        keys: Optional list of keys to apply the transform.
-    """
-
-    def __init__(self, scalar: float, keys: list[str] | None = None) -> None:
-        super().__init__(keys)
-        self.scalar = scalar
-
-    def _transform(self, data: NDArray[Any]) -> NDArray[Any]:
-        orig_endian = get_endianness(data)
-        data = data * self.scalar
-        new_endian = get_endianness(data)
-        if new_endian is not orig_endian:
-            data = data.byteswap().newbyteorder()
-        return data
-
-
 class ByteSwapTransform(Transform):
     """Byte swaps numeric data by based on target order.
 
@@ -202,22 +181,6 @@ class ByteSwapTransform(Transform):
             data = data.newbyteorder(self.target_order.symbol).byteswap()
 
         return data
-
-
-class CastTypeTransform(Transform):
-    """Casts numeric data based on target type.
-
-    Args:
-        target_type: Desired data type to cast.
-        keys: Optional list of keys to apply the transform.
-    """
-
-    def __init__(self, target_type: DTypeLike, keys: list[str] | None = None) -> None:
-        super().__init__(keys=keys)
-        self.target_type = np.dtype(target_type)
-
-    def _transform(self, data: NDArray[Any]) -> NDArray[Any]:
-        return data.astype(self.target_type)
 
 
 class IbmFloatTransform(Transform):
@@ -245,10 +208,8 @@ class TransformFactory:
     """Factory class to generate transformation strategies."""
 
     transform_map: dict[str, type[Transform]] = {
-        "scale": ScaleTransform,
         "byte_swap": ByteSwapTransform,
         "ibm_float": IbmFloatTransform,
-        "cast": CastTypeTransform,
     }
 
     @classmethod

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -193,7 +193,7 @@ class ByteSwapTransform(Transform):
         source_order = get_endianness(data)
 
         if source_order != self.target_order:
-            data = data.newbyteorder(self.target_order.symbol).byteswap()
+            data = data.byteswap(inplace=True).newbyteorder(self.target_order.symbol)
 
         return data
 

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -127,11 +127,26 @@ def _modify_structured_field(
 class Transform:
     """Base class for header transformation strategies."""
 
-    def __init__(self, keys: list[str] | None = None) -> None:
+    def __init__(self, keys: list[str] | None = None, copy: bool = False) -> None:
         self.keys = keys
+        self.copy = copy
 
     def apply(self, data: NDArray[Any]) -> NDArray[Any]:
-        """Applies transformation based on ndarray or struct array."""
+        """Applies transformation based on ndarray or struct array.
+
+        For memory efficiency, by default, the transforms are applied to input array.
+        This could cause mutation of input array depending on the transform. Set the
+        `copy` option to `True` if you want to ensure input data isn't modified.
+
+        Args:
+            data: The array to be transformed.
+
+        Returns:
+            Modified array or copy of array.
+        """
+        if self.copy:
+            data = data.copy()
+
         if self.keys is None:
             return self._transform(data)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -11,10 +11,8 @@ import pytest
 from segy.schema import Endianness
 from segy.transforms import TransformFactory
 from segy.transforms import TransformPipeline
-from segy.transforms import get_endianness
 
 if TYPE_CHECKING:
-    from numpy.typing import DTypeLike
     from numpy.typing import NDArray
 
 
@@ -83,65 +81,12 @@ class TestByteSwap:
         mock_data = request.getfixturevalue(f"mock_data_{input_endian}")
         expected_dtype = mock_data.dtype.newbyteorder(expected_order.symbol)
 
+        # Transform but make copy before because transform is in place.
         transform = TransformFactory.create("byte_swap", expected_order)
-        swapped_data = transform.apply(mock_data)
+        swapped_data = transform.apply(mock_data.copy())
 
         np.testing.assert_allclose(swapped_data, mock_data)
         assert swapped_data.dtype == expected_dtype
-
-
-@pytest.mark.parametrize("endian", [Endianness.LITTLE, Endianness.BIG])
-class TestScaling:
-    """Test scaling swap transformations."""
-
-    @pytest.mark.parametrize("fields", [None, ["field1"]])
-    def test_scale(
-        self,
-        request: pytest.FixtureRequest,
-        endian: Endianness,
-        fields: list[str] | None,
-    ) -> None:
-        """Test array scaling."""
-        scale_factor = 5
-        is_structured = fields is not None
-
-        mock_fixture = f"mock_data_{endian.value}"
-
-        if is_structured:
-            mock_fixture = mock_fixture.replace("data", "header")
-
-        mock_data = request.getfixturevalue(mock_fixture)
-
-        if is_structured and fields is not None:
-            expected = mock_data.copy()
-            for field in fields:
-                expected[field] = mock_data[field] * scale_factor
-        else:
-            expected = mock_data * scale_factor
-
-        transform = TransformFactory.create("scale", scale_factor, keys=fields)
-        scaled_data = transform.apply(mock_data)
-
-        np.testing.assert_array_equal(scaled_data, expected)
-        assert get_endianness(scaled_data) == endian
-
-    def test_scale_field_casting(
-        self,
-        request: pytest.FixtureRequest,
-        endian: Endianness,
-    ) -> None:
-        """Test casted structured field scaling."""
-        mock_data = request.getfixturevalue(f"mock_header_{endian.value}")
-
-        scale_factor = 0.1
-        keys = ["field1"]
-        expected = (4.2, 1, 3.1415)
-
-        transform = TransformFactory.create("scale", scale_factor, keys=keys)
-        scaled_data = transform.apply(mock_data)
-
-        np.testing.assert_array_almost_equal(scaled_data.item(), expected)
-        assert get_endianness(scaled_data) == endian
 
 
 class TestIbmFloat:
@@ -183,106 +128,39 @@ class TestIbmFloat:
         assert transformed_header[0].item() == expected.item()
 
 
-@pytest.mark.parametrize(
-    ("endian", "cast_to"),
-    [
-        (Endianness.LITTLE, "<i4"),
-        (Endianness.BIG, ">i4"),
-    ],
-)
-class TestCastType:
-    """Test dtype casting transforms."""
-
-    def test_cast_dtype(
-        self,
-        request: pytest.FixtureRequest,
-        endian: Endianness,
-        cast_to: DTypeLike,
-    ) -> None:
-        """Test array casting with little endian."""
-        mock_data = request.getfixturevalue(f"mock_data_{endian.value}")
-        expected = mock_data.astype(cast_to)
-
-        transform = TransformFactory.create("cast", cast_to)
-        cast_data = transform.apply(mock_data)
-
-        np.testing.assert_array_equal(cast_data, expected)
-        assert get_endianness(cast_data) == endian
-
-    def test_cast_dtype_field(
-        self,
-        request: pytest.FixtureRequest,
-        endian: Endianness,
-        cast_to: DTypeLike,
-    ) -> None:
-        """Test structured array field casting with little endian."""
-        mock_data = request.getfixturevalue(f"mock_header_{endian.value}")
-        expected = (42, 1, 3)
-
-        transform = TransformFactory.create("cast", cast_to, keys=["field3"])
-        cast_data = transform.apply(mock_data)
-
-        np.testing.assert_array_equal(cast_data.item(), expected)
-        assert get_endianness(cast_data) == endian
-
-
 class TestTransformPipeline:
     """Tests for transform pipeline and transform integration."""
 
-    @staticmethod
-    def build_transform_pipeline(
-        scale_factor: int,
-        fields: list[str] | None,
-    ) -> TransformPipeline:
-        """Build common transform pipeline for tests."""
-        cast_type = "float16"
-
-        scale_transform = TransformFactory.create("scale", scale_factor, keys=fields)
-        endian_transform = TransformFactory.create("byte_swap", Endianness.LITTLE)
-        cast_transform = TransformFactory.create("cast", cast_type, keys=fields)
+    def test_transform_pipeline(self, mock_data_little: NDArray[Any]) -> None:
+        """Test transformation pipeline and transform integration."""
+        expected_data = mock_data_little.copy()
 
         pipeline = TransformPipeline()
-        pipeline.add_transform(scale_transform)
-        pipeline.add_transform(endian_transform)
-        pipeline.add_transform(cast_transform)
+        pipeline.add_transform(TransformFactory.create("byte_swap", Endianness.BIG))
+        pipeline.add_transform(TransformFactory.create("byte_swap", Endianness.LITTLE))
 
-        return pipeline
-
-    def test_transform_pipeline(self, mock_data_big: NDArray[Any]) -> None:
-        """Test transformation pipeline and transform integration."""
-        scale_factor = 3
-        expected_data = mock_data_big.byteswap().newbyteorder()
-        expected_data = (expected_data * scale_factor).astype("float16")
-
-        expected_dtype = expected_data.dtype
-
-        pipeline = self.build_transform_pipeline(scale_factor=scale_factor, fields=None)
-
-        transformed_data = pipeline.apply(mock_data_big)
+        transformed_data = pipeline.apply(mock_data_little)
         np.testing.assert_allclose(transformed_data, expected_data)
-        assert transformed_data.dtype == expected_dtype
+        assert transformed_data.dtype == expected_data.dtype
 
-    def test_transform_pipeline_field(self, mock_header_big: NDArray[Any]) -> None:
+    def test_transform_pipeline_field(self, mock_header_ibm: NDArray[Any]) -> None:
         """Test transformation pipeline and transform integration for struct fields."""
-        scale_factor = 3
-        fields = ["field2", "field3"]
+        expected_dtype = [
+            ("u4_field", "uint32"),
+            ("ibm_field", "float32"),
+            ("u2_field", "uint16"),
+            ("ibm_field2", "float32"),
+        ]
+        expected_data = np.asarray((256, 118.625, 8, 3.141593), dtype=expected_dtype)
 
-        names = ["field1", "field2", "field3"]
-        formats = ["<u4", "<f2", "<f2"]
-        expected_dtype = np.dtype({"names": names, "formats": formats})
+        keys = ["ibm_field", "ibm_field2"]
+        pipeline = TransformPipeline()
+        pipeline.add_transform(TransformFactory.create("byte_swap", Endianness.BIG))
+        pipeline.add_transform(TransformFactory.create("byte_swap", Endianness.LITTLE))
+        pipeline.add_transform(TransformFactory.create("ibm_float", "to_ieee", keys))
 
-        expected_data = mock_header_big.copy()
-        for field in fields:
-            expected_data[field] = expected_data[field] * scale_factor
+        transformed_data = pipeline.apply(mock_header_ibm.copy())
 
-        expected_data = expected_data.byteswap().newbyteorder()
-        expected_data = expected_data.astype(expected_dtype)
-
-        pipeline = self.build_transform_pipeline(
-            scale_factor=scale_factor, fields=fields
-        )
-
-        transformed_data = pipeline.apply(mock_header_big)
         assert transformed_data == expected_data
         assert transformed_data.dtype == expected_dtype
 
@@ -292,12 +170,12 @@ class TestTransformPipeline:
         mock_header_big: NDArray[Any],
     ) -> None:
         """Test transformation field errors."""
-        scale_transform = TransformFactory.create("scale", 1, ["field1"])
+        scale_transform = TransformFactory.create("ibm_float", "to_ibm", ["field1"])
         with pytest.raises(ValueError, match="doesn't contain any fields"):
             scale_transform.apply(mock_data_little)
 
-        scale_transform = TransformFactory.create("scale", 1, ["non_existent"])
-        with pytest.raises(ValueError, match="{'non_existent'} not in the array"):
+        scale_transform = TransformFactory.create("ibm_float", "to_ibm", ["unknown"])
+        with pytest.raises(ValueError, match="{'unknown'} not in the array"):
             scale_transform.apply(mock_header_big)
 
     def test_transform_factory_exception(self) -> None:


### PR DESCRIPTION
Made byte-swapping in-place. IBM to IEEE is already in place. Not sure about IEEE to IBM, will check that if it becomes a problem.

Removed the scaling and casting transforms because we don't need them anymore. This also allowed us to simplify the dtype casting logic for transforms since the data type itemsize isn't expected to change anymore.