### PR TITLE
Refactor SEG-Y standard registration and retrieval and make it more strict

### DIFF
--- a/src/segy/cli/dump.py
+++ b/src/segy/cli/dump.py
@@ -28,7 +28,7 @@ def info(uri: UriArgument, output: JsonFileOutOption = None) -> None:
 
     info = SegyInfo(
         uri=uri,
-        segy_standard=spec.segy_standard.value,
+        segy_standard=spec.segy_standard,
         num_traces=segy.num_traces,
         samples_per_trace=segy.samples_per_trace,
         sample_interval=segy.sample_interval,

--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -62,7 +62,7 @@ class SegyFactory:
         return self.spec.trace.sample_descriptor.format
 
     @property
-    def segy_revision(self) -> SegyStandard:
+    def segy_revision(self) -> SegyStandard | None:
         """Revision of the SEG-Y file."""
         return self.spec.segy_standard
 
@@ -96,7 +96,8 @@ class SegyFactory:
         binary_descriptor = self.spec.binary_file_header
         bin_header = np.zeros(shape=1, dtype=binary_descriptor.dtype)
 
-        if self.segy_revision != SegyStandard.REV0:
+        rev0 = self.segy_revision == SegyStandard.REV0
+        if self.segy_revision is not None and not rev0:
             bin_header["seg_y_revision"] = self.segy_revision.value * 256
 
         bin_header["sample_interval"] = self.sample_interval

--- a/src/segy/file.py
+++ b/src/segy/file.py
@@ -17,7 +17,7 @@ from segy.indexing import TraceIndexer
 from segy.schema import Endianness
 from segy.schema import ScalarType
 from segy.schema import SegyStandard
-from segy.standards import registry
+from segy.standards import get_segy_standard
 from segy.standards.mapping import SEGY_FORMAT_MAP
 from segy.standards.rev1 import rev1_binary_file_header
 from segy.standards.rev1 import rev1_extended_text_header
@@ -38,7 +38,7 @@ def create_spec(
     sample_format: ScalarType | None = None,
 ) -> SegyDescriptor:
     """Create SegyDescriptor from SegyStandard, Endianness, and ScalarType."""
-    spec = registry.get_spec(standard)
+    spec = get_segy_standard(standard)
     spec.endianness = endian
 
     if sample_format is not None:

--- a/src/segy/schema/segy.py
+++ b/src/segy/schema/segy.py
@@ -26,14 +26,12 @@ class SegyStandard(Enum):
     REV1 = 1.0
     REV2 = 2.0
     REV21 = 2.1
-    CUSTOM = "custom"
-    MINIMAL = "minimal"
 
 
 class SegyDescriptor(CamelCaseModel):
     """A descriptor class for a SEG-Y file."""
 
-    segy_standard: SegyStandard = Field(
+    segy_standard: SegyStandard | None = Field(
         ..., description="SEG-Y Revision / Standard. Can also be custom."
     )
     text_file_header: TextHeaderDescriptor = Field(
@@ -80,7 +78,7 @@ class SegyDescriptor(CamelCaseModel):
             A modified SEG-Y descriptor with "custom" segy standard.
         """
         new_descr = self.model_copy(deep=True)
-        new_descr.segy_standard = SegyStandard.CUSTOM
+        new_descr.segy_standard = None
 
         if text_header_spec:
             new_descr.text_file_header = text_header_spec

--- a/src/segy/schema/segy.py
+++ b/src/segy/schema/segy.py
@@ -107,7 +107,7 @@ class SegyInfo(CamelCaseModel):
 
     uri: str = Field(..., description="URI of the SEG-Y file.")
 
-    segy_standard: SegyStandard = Field(
+    segy_standard: SegyStandard | None = Field(
         ..., description="SEG-Y Revision / Standard. Can also be custom."
     )
 

--- a/src/segy/standards/__init__.py
+++ b/src/segy/standards/__init__.py
@@ -1,14 +1,13 @@
 """Implementation of SEG-Y standards."""
 
 from segy.schema import SegyStandard
-from segy.standards.minimal import minimal_segy
-from segy.standards.registry import register_spec
+from segy.standards.registry import get_segy_standard
+from segy.standards.registry import register_segy_standard
 from segy.standards.rev0 import rev0_segy
 from segy.standards.rev1 import rev1_segy
 
-register_spec(SegyStandard.MINIMAL, minimal_segy)
-register_spec(SegyStandard.REV0, rev0_segy)
-register_spec(SegyStandard.REV1, rev1_segy)
+register_segy_standard(SegyStandard.REV0, rev0_segy)
+register_segy_standard(SegyStandard.REV1, rev1_segy)
 
 
-__all__ = ["minimal_segy", "rev0_segy", "rev1_segy", "SegyStandard"]
+__all__ = ["get_segy_standard", "SegyStandard"]

--- a/src/segy/standards/minimal.py
+++ b/src/segy/standards/minimal.py
@@ -2,7 +2,6 @@
 
 from segy.schema import ScalarType
 from segy.schema import SegyDescriptor
-from segy.schema import SegyStandard
 from segy.schema import TextHeaderDescriptor
 from segy.schema import TextHeaderEncoding
 from segy.schema import TraceDescriptor
@@ -79,7 +78,7 @@ trace_data = TraceSampleDescriptor(format=ScalarType.IBM32)
 trace = TraceDescriptor(header_descriptor=trace_header, sample_descriptor=trace_data)
 
 minimal_segy = SegyDescriptor(
-    segy_standard=SegyStandard.MINIMAL,
+    segy_standard=None,
     text_file_header=textual_file_header,
     binary_file_header=binary_file_header,
     trace=trace,

--- a/src/segy/standards/registry.py
+++ b/src/segy/standards/registry.py
@@ -8,17 +8,17 @@ if TYPE_CHECKING:
     from segy.schema.segy import SegyDescriptor
     from segy.schema.segy import SegyStandard
 
-registry = {}
+segy_standard_registry = {}
 
 
-def register_spec(spec_type: SegyStandard, spec: SegyDescriptor) -> None:
+def register_segy_standard(spec_type: SegyStandard, spec: SegyDescriptor) -> None:
     """Register a SEG-Y standard with its descriptor."""
-    registry[spec_type] = spec
+    segy_standard_registry[spec_type] = spec
 
 
-def get_spec(spec_type: SegyStandard) -> SegyDescriptor:
+def get_segy_standard(spec_type: SegyStandard) -> SegyDescriptor:
     """Get a registered SEG-Y standard's descriptor."""
-    spec = registry.get(spec_type)
+    spec = segy_standard_registry.get(spec_type)
 
     if spec is None:
         msg = (

--- a/tests/test_schema_segy.py
+++ b/tests/test_schema_segy.py
@@ -10,14 +10,14 @@ from segy.schema import TextHeaderDescriptor
 from segy.schema import TextHeaderEncoding
 from segy.schema import TraceSampleDescriptor
 from segy.standards import SegyStandard
-from segy.standards import registry
+from segy.standards import get_segy_standard
 
 
 @pytest.fixture(params=[SegyStandard.REV0, SegyStandard.REV1])
 def segy_descriptor(request: pytest.FixtureRequest) -> SegyDescriptor:
     """Fixture for creating known SegyDescriptor instances for customizing."""
     standard = request.param
-    return registry.get_spec(standard)
+    return get_segy_standard(standard)
 
 
 class TestSegyDescriptorCustomize:
@@ -34,7 +34,7 @@ class TestSegyDescriptorCustomize:
 
         custom_spec = segy_descriptor.customize(text_header_spec=custom_text_descr)
 
-        assert custom_spec.segy_standard == SegyStandard.CUSTOM
+        assert custom_spec.segy_standard is None
         assert custom_spec.text_file_header == custom_text_descr
 
     def test_custom_binary_file_headers(self, segy_descriptor: SegyDescriptor) -> None:
@@ -48,7 +48,7 @@ class TestSegyDescriptorCustomize:
         custom_spec = segy_descriptor.customize(binary_header_fields=custom_fields)
 
         expected_itemsize = segy_descriptor.binary_file_header.dtype.itemsize
-        assert custom_spec.segy_standard == SegyStandard.CUSTOM
+        assert custom_spec.segy_standard is None
         assert len(custom_spec.binary_file_header.fields) == len(custom_fields)
         assert custom_spec.binary_file_header.dtype.names == ("f1", "f2", "f3")
         assert custom_spec.binary_file_header.dtype.itemsize == expected_itemsize
@@ -63,7 +63,7 @@ class TestSegyDescriptorCustomize:
         custom_spec = segy_descriptor.customize(trace_header_fields=custom_fields)
 
         expected_itemsize = segy_descriptor.trace.header_descriptor.dtype.itemsize
-        assert custom_spec.segy_standard == SegyStandard.CUSTOM
+        assert custom_spec.segy_standard is None
         assert len(custom_spec.trace.header_descriptor.fields) == len(custom_fields)
         assert custom_spec.trace.header_descriptor.dtype.names == ("f1", "f2")
         assert custom_spec.trace.header_descriptor.dtype.itemsize == expected_itemsize
@@ -79,7 +79,7 @@ class TestSegyDescriptorCustomize:
 
         custom_spec = segy_descriptor.customize(extended_text_spec=custom_text_descr)
 
-        assert custom_spec.segy_standard == SegyStandard.CUSTOM
+        assert custom_spec.segy_standard is None
         assert custom_spec.extended_text_header == custom_text_descr
 
     def test_custom_trace_samples(self, segy_descriptor: SegyDescriptor) -> None:
@@ -89,7 +89,7 @@ class TestSegyDescriptorCustomize:
         custom_spec = segy_descriptor.customize(trace_data_spec=custom_samples)
 
         expected_subdtype = (np.dtype("uint16"), (3,))
-        assert custom_spec.segy_standard == SegyStandard.CUSTOM
+        assert custom_spec.segy_standard is None
         assert custom_spec.trace.dtype.itemsize == 246  # noqa: PLR2004
         assert custom_spec.trace.sample_descriptor.dtype.itemsize == 6  # noqa: PLR2004
         assert custom_spec.trace.sample_descriptor.dtype.subdtype == expected_subdtype

--- a/tests/test_segy_factory.py
+++ b/tests/test_segy_factory.py
@@ -102,7 +102,7 @@ def test_binary_file_header(
         mock_segy_factory.samples_per_trace,
         mock_segy_factory.samples_per_trace,
         SEGY_FORMAT_MAP[mock_segy_factory.trace_sample_format],
-        mock_segy_factory.segy_revision.value * 256,
+        mock_segy_factory.segy_revision.value * 256,  # type: ignore[union-attr]
         0,  # fixed length trace flag
         0,  # extended text headers
     )

--- a/tests/test_segy_factory.py
+++ b/tests/test_segy_factory.py
@@ -16,8 +16,8 @@ from segy.schema import ScalarType
 from segy.schema import SegyStandard
 from segy.schema import StructuredFieldDescriptor
 from segy.schema import TextHeaderEncoding
-from segy.standards import registry
 from segy.standards.mapping import SEGY_FORMAT_MAP
+from segy.standards.minimal import minimal_segy
 
 
 @dataclass
@@ -45,7 +45,7 @@ def mock_segy_factory(request: pytest.FixtureRequest) -> SegyFactory:
     files parametrically. `SEGY_FACTORY_TEST_CONFIGS` defines the base configuration.
     """
     test_config = request.param
-    spec = registry.get_spec(SegyStandard.MINIMAL)
+    spec = minimal_segy
 
     # Set file wide attributes
     spec.endianness = test_config.endianness
@@ -71,7 +71,7 @@ def mock_segy_factory(request: pytest.FixtureRequest) -> SegyFactory:
 )
 def test_textual_file_header(encoding: TextHeaderEncoding) -> None:
     """Tests that the textual file header is written correctly."""
-    spec = registry.get_spec(SegyStandard.MINIMAL)
+    spec = minimal_segy
     spec.text_file_header.encoding = encoding
     factory = SegyFactory(spec)
 
@@ -216,7 +216,7 @@ class TestSegyFactoryExceptions:
 
     def test_create_trace_incorrect_ndim(self) -> None:
         """Check if trace dimensions are wrong."""
-        spec = registry.get_spec(SegyStandard.MINIMAL)
+        spec = minimal_segy
         factory = SegyFactory(spec, sample_interval=2, samples_per_trace=5)
 
         header_1d = factory.create_trace_header_template(5)
@@ -227,7 +227,7 @@ class TestSegyFactoryExceptions:
 
     def test_create_sample_num_samples_mismatch(self) -> None:
         """Check if trace number of samples are wrong."""
-        spec = registry.get_spec(SegyStandard.MINIMAL)
+        spec = minimal_segy
         factory = SegyFactory(spec, sample_interval=2, samples_per_trace=5)
 
         header_1d = factory.create_trace_header_template(size=5)
@@ -238,7 +238,7 @@ class TestSegyFactoryExceptions:
 
     def test_create_header_sample_mismatch(self) -> None:
         """Check if headers and traces are different sizes."""
-        spec = registry.get_spec(SegyStandard.MINIMAL)
+        spec = minimal_segy
         factory = SegyFactory(spec, sample_interval=2, samples_per_trace=11)
 
         header_1d = factory.create_trace_header_template(size=5)

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -18,7 +18,7 @@ from segy.factory import DEFAULT_TEXT_HEADER
 from segy.schema import Endianness
 from segy.schema import ScalarType
 from segy.schema import SegyStandard
-from segy.standards import registry
+from segy.standards import get_segy_standard
 from segy.standards.mapping import SEGY_FORMAT_MAP
 
 if TYPE_CHECKING:
@@ -82,7 +82,7 @@ def generate_test_segy(
     sample_format: ScalarType = ScalarType.IBM32,
 ) -> SegyFileTestConfig:
     """Function for mocking a SEG-Y file with in memory URI."""
-    spec = registry.get_spec(segy_standard)
+    spec = get_segy_standard(segy_standard)
     spec.endianness = endianness
     spec.trace.sample_descriptor.format = sample_format
 

--- a/tests/test_standards_registry.py
+++ b/tests/test_standards_registry.py
@@ -4,19 +4,20 @@ import pytest
 
 from segy.schema import SegyDescriptor
 from segy.standards import SegyStandard
-from segy.standards import rev0_segy
-from segy.standards import rev1_segy
-from segy.standards.registry import get_spec
-from segy.standards.registry import register_spec
+from segy.standards import get_segy_standard
+from segy.standards.rev0 import rev0_segy
+from segy.standards.rev1 import rev1_segy
 
 
 @pytest.mark.parametrize(
     ("standard_enum", "standard_spec"),
     [(SegyStandard.REV0, rev0_segy), (SegyStandard.REV1, rev1_segy)],
 )
-def test_get_spec(standard_enum: SegyStandard, standard_spec: SegyDescriptor) -> None:
+def test_get_standard(
+    standard_enum: SegyStandard, standard_spec: SegyDescriptor
+) -> None:
     """Test retrieving SegyStandard from registry."""
-    spec_copy = get_spec(SegyStandard(standard_enum))
+    spec_copy = get_segy_standard(standard_enum)
     assert spec_copy == standard_spec
     assert id(spec_copy) != id(standard_spec)
 
@@ -24,11 +25,4 @@ def test_get_spec(standard_enum: SegyStandard, standard_spec: SegyDescriptor) ->
 def test_get_nonexistent_spec_error() -> None:
     """Test missing / non-existent SegyStandard from registry."""
     with pytest.raises(NotImplementedError):
-        get_spec("non_existent")  # type: ignore
-
-
-def test_register_custom_descriptor() -> None:
-    """Test registering a custom descriptor."""
-    spec = rev1_segy.customize(extended_text_spec=rev1_segy.text_file_header)
-    register_spec(SegyStandard.CUSTOM, spec)
-    assert get_spec(SegyStandard.CUSTOM) == spec
+        get_segy_standard("non_existent")  # type: ignore


### PR DESCRIPTION
The SEG-Y standard registration method and retrieval method have been renamed for clarity. Now, they are called `register_segy_standard` and `get_segy_standard`. Also, the `SegyStandard` property for `SegyDescriptor` and all its references is updated which can be `None`. This change helps with custom schemas and makes the numbering more strict. 

We only allow `{0.0, 1.0, 2.0, 2.1, None}` as values now.