### PR TITLE
Update canonical SEG-Y header field names in SEGY standards revisions 0 and 1

### DIFF
--- a/src/segy/standards/rev0.py
+++ b/src/segy/standards/rev0.py
@@ -209,7 +209,7 @@ TRACE_HEADER_FIELDS_REV0 = [
         description="Energy Source Point Number",
     ),
     StructuredFieldDescriptor(
-        name="cdp_ens_no",
+        name="ensemble_no",
         offset=20,
         format=ScalarType.INT32,
         description="Ensemble Number (CDP, CMP, etc.)",
@@ -227,7 +227,7 @@ TRACE_HEADER_FIELDS_REV0 = [
         description="Trace Identification Code",
     ),
     StructuredFieldDescriptor(
-        name="vert_sum",
+        name="vertical_sum",
         offset=30,
         format=ScalarType.INT16,
         description="Number of Vertically Stacked Traces",

--- a/src/segy/standards/rev1.py
+++ b/src/segy/standards/rev1.py
@@ -37,37 +37,37 @@ BINARY_FILE_HEADER_FIELDS_REV1 = BINARY_FILE_HEADER_FIELDS_REV0 + [
 
 TRACE_HEADER_FIELDS_REV1 = TRACE_HEADER_FIELDS_REV0 + [
     StructuredFieldDescriptor(
-        name="x_coordinate",
+        name="cdp_x",
         offset=180,
         format=ScalarType.INT32,
         description="X coordinate of ensemble (CDP) position",
     ),
     StructuredFieldDescriptor(
-        name="y_coordinate",
+        name="cdp_y",
         offset=184,
         format=ScalarType.INT32,
         description="Y coordinate of ensemble (CDP) position",
     ),
     StructuredFieldDescriptor(
-        name="inline_no",
+        name="inline",
         offset=188,
         format=ScalarType.INT32,
         description="Inline number",
     ),
     StructuredFieldDescriptor(
-        name="crossline_no",
+        name="crossline",
         offset=192,
         format=ScalarType.INT32,
         description="Crossline number",
     ),
     StructuredFieldDescriptor(
-        name="shotpoint_no",
+        name="shot_point",
         offset=196,
         format=ScalarType.INT32,
         description="Shotpoint number",
     ),
     StructuredFieldDescriptor(
-        name="scalar_apply_shotpoint",
+        name="shot_point_scalar",
         offset=200,
         format=ScalarType.INT16,
         description="Scalar to be applied to the shotpoint number",


### PR DESCRIPTION
The field names in trace header fields for SEGY standards rev 0 and 1 have been revised. In revision 1, "x_coordinate" has been changed to "cdp_x", "y_coordinate" to "cdp_y", etc. For revision 0, "cdp_ens_no" is now "ensemble_no" and "vert_sum" is updated to "vertical_sum". These changes aim to enhance consistency with standards.