### PR TITLE
Added SEG-Y Rev 2.0 fields to registry.

### DIFF
--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -98,7 +98,18 @@ class SegyFactory:
 
         rev0 = self.segy_revision == SegyStandard.REV0
         if self.segy_revision is not None and not rev0:
-            bin_header["seg_y_revision"] = self.segy_revision.value * 256
+            major, minor = divmod(self.segy_revision.value * 10, 10)
+
+            # Handle the case where rev1.0 and little-endian. Flip major/minor.
+            # In rev2+ endianness is not applicable in revision fields because
+            # they're single byte.
+            rev1 = self.segy_revision == SegyStandard.REV1
+            little_endian = self.spec.endianness == Endianness.LITTLE
+            if rev1 and little_endian:
+                major, minor = 0, 1
+
+            bin_header["seg_y_revision_major"] = major
+            bin_header["seg_y_revision_minor"] = minor
 
         bin_header["sample_interval"] = self.sample_interval
         bin_header["sample_interval_orig"] = self.sample_interval

--- a/src/segy/file.py
+++ b/src/segy/file.py
@@ -77,9 +77,16 @@ def unpack_binary_header(
     # Get sample format
     sample_format = struct.unpack_from(format_, buffer, offset=24)[0]
 
-    # # Get revision. Per SEG-Y standard, there is a Q-point between the
-    # bytes. Dividing by 2^8 to get the floating-point value of the revision.
-    revision = struct.unpack_from(format_, buffer, offset=300)[0] / 256.0
+    # Get revision
+    revision_major = struct.unpack_from("B", buffer, offset=300)[0]
+    revision_minor = struct.unpack_from("B", buffer, offset=301)[0]
+
+    # Handle the case where rev1.0 and little-endian. Flip major/minor. In rev2+
+    # endianness is not applicable in revision fields because they're single byte.
+    if revision_minor == 1 and revision_major == 0:
+        revision_major, revision_minor = 1, 0
+
+    revision = float(f"{revision_major}.{revision_minor}")
 
     return sample_increment, revision, sample_format
 

--- a/src/segy/schema/data_type.py
+++ b/src/segy/schema/data_type.py
@@ -54,6 +54,7 @@ class ScalarType(StrEnum):
     FLOAT64 = "float64"
     FLOAT32 = "float32"
     FLOAT16 = "float16"
+    STRING8 = "S8"
 
     @property
     def char(self) -> str:

--- a/src/segy/schema/segy.py
+++ b/src/segy/schema/segy.py
@@ -27,6 +27,16 @@ class SegyStandard(Enum):
     REV2 = 2.0
     REV21 = 2.1
 
+    @property
+    def major(self) -> int:
+        """Get the major value of the SEG-Y standard."""
+        return int(str(self.value).split(".")[0])
+
+    @property
+    def minor(self) -> int:
+        """Get the minor value of the SEG-Y standard."""
+        return int(str(self.value).split(".")[1])
+
 
 class SegyDescriptor(CamelCaseModel):
     """A descriptor class for a SEG-Y file."""

--- a/src/segy/standards/__init__.py
+++ b/src/segy/standards/__init__.py
@@ -5,9 +5,11 @@ from segy.standards.registry import get_segy_standard
 from segy.standards.registry import register_segy_standard
 from segy.standards.rev0 import rev0_segy
 from segy.standards.rev1 import rev1_segy
+from segy.standards.rev2 import rev2_segy
 
 register_segy_standard(SegyStandard.REV0, rev0_segy)
 register_segy_standard(SegyStandard.REV1, rev1_segy)
+register_segy_standard(SegyStandard.REV2, rev2_segy)
 
 
 __all__ = ["get_segy_standard", "SegyStandard"]

--- a/src/segy/standards/minimal.py
+++ b/src/segy/standards/minimal.py
@@ -42,10 +42,16 @@ BINARY_FILE_HEADER_FIELDS = [
         description="Data Sample Format Code",
     ),
     StructuredFieldDescriptor(
-        name="seg_y_revision",
+        name="seg_y_revision_major",
         byte=301,
-        format=ScalarType.INT16,
-        description="SEG Y Format Revision Number",
+        format=ScalarType.UINT8,
+        description="SEG Y Format Revision Major Number",
+    ),
+    StructuredFieldDescriptor(
+        name="seg_y_revision_minor",
+        byte=302,
+        format=ScalarType.UINT8,
+        description="SEG Y Format Revision Minor Number",
     ),
     StructuredFieldDescriptor(
         name="fixed_length_trace_flag",

--- a/src/segy/standards/rev1.py
+++ b/src/segy/standards/rev1.py
@@ -15,10 +15,16 @@ from segy.standards.rev0 import TRACE_HEADER_FIELDS_REV0
 
 BINARY_FILE_HEADER_FIELDS_REV1 = BINARY_FILE_HEADER_FIELDS_REV0 + [
     StructuredFieldDescriptor(
-        name="seg_y_revision",
+        name="seg_y_revision_major",
         byte=301,
-        format=ScalarType.INT16,
-        description="SEG Y Format Revision Number",
+        format=ScalarType.UINT8,
+        description="SEG Y Format Revision Major Number",
+    ),
+    StructuredFieldDescriptor(
+        name="seg_y_revision_minor",
+        byte=302,
+        format=ScalarType.UINT8,
+        description="SEG Y Format Revision Minor Number",
     ),
     StructuredFieldDescriptor(
         name="fixed_length_trace_flag",

--- a/src/segy/standards/rev2.py
+++ b/src/segy/standards/rev2.py
@@ -1,0 +1,321 @@
+"""SEG-Y Revision 2 Specification."""
+
+from segy.schema import Endianness
+from segy.schema import ScalarType
+from segy.schema import SegyDescriptor
+from segy.schema import SegyStandard
+from segy.schema import TextHeaderDescriptor
+from segy.schema import TextHeaderEncoding
+from segy.schema import TraceDescriptor
+from segy.schema import TraceSampleDescriptor
+from segy.schema.data_type import StructuredDataTypeDescriptor
+from segy.schema.data_type import StructuredFieldDescriptor
+from segy.standards.rev1 import BINARY_FILE_HEADER_FIELDS_REV1
+from segy.standards.rev1 import TRACE_HEADER_FIELDS_REV1
+
+BINARY_FILE_HEADER_FIELDS_REV2 = BINARY_FILE_HEADER_FIELDS_REV1 + [
+    StructuredFieldDescriptor(
+        name="extended_data_traces_ensemble",
+        offset=60,
+        format=ScalarType.INT32,
+        description="Extended number of data traces per ensemble.",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_aux_traces_ensemble",
+        offset=64,
+        format=ScalarType.INT32,
+        description="Extended number of auxiliary traces per ensemble.",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_samples_per_trace",
+        offset=68,
+        format=ScalarType.INT32,
+        description="Extended number of samples per data trace.",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_sample_interval",
+        offset=72,
+        format=ScalarType.FLOAT64,
+        description="Extended sample interval, IEEE double precision.",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_sample_interval_orig",
+        offset=80,
+        format=ScalarType.FLOAT64,
+        description="Extended sample interval of original field recording.",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_samples_per_trace_orig",
+        offset=88,
+        format=ScalarType.INT32,
+        description="Extended number of samples per data trace in original recording.",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_ensemble_fold",
+        offset=92,
+        format=ScalarType.INT32,
+        description="Extended ensemble fold.",
+    ),
+    StructuredFieldDescriptor(
+        name="endian_indicator",
+        offset=96,
+        format=ScalarType.INT32,
+        description="The integer constants for endianness. Indicates byte ordering.",
+    ),
+    StructuredFieldDescriptor(
+        name="max_extended_trace_headers",
+        offset=306,
+        format=ScalarType.INT32,
+        description="Maximum number of additional 240 byte trace headers.",
+    ),
+    StructuredFieldDescriptor(
+        name="time_basis_code",
+        offset=310,
+        format=ScalarType.INT16,
+        description="Time Basis Code",
+    ),
+    StructuredFieldDescriptor(
+        name="no_traces",
+        offset=312,
+        format=ScalarType.UINT64,
+        description="Time Basis Code",
+    ),
+    StructuredFieldDescriptor(
+        name="first_trace_offset",
+        offset=320,
+        format=ScalarType.UINT64,
+        description="Byte offset of first trace relative to start of file or stream.",
+    ),
+    StructuredFieldDescriptor(
+        name="no_data_trailer_records",
+        offset=328,
+        format=ScalarType.INT32,
+        description="Number of 3200-byte data trailer stanza records following last trace.",
+    ),
+]
+
+
+TRACE_HEADER_FIELDS_REV2 = TRACE_HEADER_FIELDS_REV1 + [
+    StructuredFieldDescriptor(
+        name="trace_header_name",
+        offset=232,
+        format=ScalarType.STRING8,
+        description="Either zero or trace header name 'SEG00000' in ASCII or EBCDIC.",
+    ),
+]
+
+EXTENDED_TRACE_HEADER_FIELDS_REV2 = [
+    StructuredFieldDescriptor(
+        name="extended_trace_seq_line",
+        offset=0,
+        format=ScalarType.UINT64,
+        description="Extended trace sequence number within line",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_trace_seq_file",
+        offset=8,
+        format=ScalarType.UINT64,
+        description="Extended trace sequence number within SEG-Y file",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_field_rec_no",
+        offset=16,
+        format=ScalarType.INT64,
+        description="Extended original field record number",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_ensemble_no",
+        offset=24,
+        format=ScalarType.INT64,
+        description="Extended ensemble number",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_rec_elev",
+        offset=32,
+        format=ScalarType.FLOAT64,
+        description="Extended elevation of receiver group",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_rec_depth",
+        offset=40,
+        format=ScalarType.FLOAT64,
+        description="Receiver group depth below surface",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_src_elev",
+        offset=48,
+        format=ScalarType.FLOAT64,
+        description="Extended surface elevation at source location",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_src_depth",
+        offset=56,
+        format=ScalarType.FLOAT64,
+        description="Extended source depth below surface",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_datum_elev_rec",
+        offset=64,
+        format=ScalarType.FLOAT64,
+        description="Extended Seismic Datum elevation at receiver group",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_datum_elev_src",
+        offset=72,
+        format=ScalarType.FLOAT64,
+        description="Extended Seismic Datum elevation at source",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_water_depth_src",
+        offset=80,
+        format=ScalarType.FLOAT64,
+        description="Extended water column height at source location",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_water_depth_rec",
+        offset=88,
+        format=ScalarType.FLOAT64,
+        description="Extended water column height at receiver group location",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_src_x",
+        offset=96,
+        format=ScalarType.FLOAT64,
+        description="Extended source coordinate - X",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_src_y",
+        offset=104,
+        format=ScalarType.FLOAT64,
+        description="Extended source coordinate - Y",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_rec_x",
+        offset=112,
+        format=ScalarType.FLOAT64,
+        description="Extended group coordinate - X",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_rec_y",
+        offset=120,
+        format=ScalarType.FLOAT64,
+        description="Extended group coordinate - Y",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_dist_src_to_rec",
+        offset=128,
+        format=ScalarType.FLOAT64,
+        description="Distance from center of the source to the center of the receiver",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_samples_per_trace",
+        offset=136,
+        format=ScalarType.UINT32,
+        description="Extended number of samples in this trace",
+    ),
+    StructuredFieldDescriptor(
+        name="nanoseconds_to_add",
+        offset=140,
+        format=ScalarType.INT32,
+        description="Nanoseconds to add to Second of minute",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_sample_interval",
+        offset=144,
+        format=ScalarType.FLOAT64,
+        description="Extended, microsecond sample interval",
+    ),
+    StructuredFieldDescriptor(
+        name="cable_or_rec_id",
+        offset=152,
+        format=ScalarType.INT32,
+        description="Cable number for multi-cable acquisition or Recording Device/Sensor ID number",
+    ),
+    StructuredFieldDescriptor(
+        name="num_additional_extended_headers",
+        offset=156,
+        format=ScalarType.UINT16,
+        description="Number of additional trace header extension blocks including this one",
+    ),
+    StructuredFieldDescriptor(
+        name="last_trace_flag",
+        offset=158,
+        format=ScalarType.INT16,
+        description="Last trace flag",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_x_coord_ensemble",
+        offset=160,
+        format=ScalarType.FLOAT64,
+        description="Extended X coordinate of ensemble (CDP) position of this trace",
+    ),
+    StructuredFieldDescriptor(
+        name="extended_y_coord_ensemble",
+        offset=168,
+        format=ScalarType.FLOAT64,
+        description="Extended Y coordinate of ensemble (CDP) position of this trace",
+    ),
+    StructuredFieldDescriptor(
+        name="trace_header_name",
+        offset=232,
+        format=ScalarType.STRING8,
+        description="Eight character trace header name",
+    ),
+]
+
+
+rev2_textual_file_header = TextHeaderDescriptor(
+    rows=40,
+    cols=80,
+    offset=0,
+    encoding=TextHeaderEncoding.EBCDIC,
+    format=ScalarType.UINT8,  # noqa: A003
+)
+
+
+rev2_binary_file_header = StructuredDataTypeDescriptor(
+    fields=BINARY_FILE_HEADER_FIELDS_REV2,
+    item_size=400,
+    offset=3200,
+)
+
+
+rev2_extended_text_header = TextHeaderDescriptor(
+    rows=40,
+    cols=80,
+    offset=3600,
+    encoding=TextHeaderEncoding.EBCDIC,
+    format=ScalarType.UINT8,  # noqa: A003
+)
+
+
+rev2_trace_header = StructuredDataTypeDescriptor(
+    fields=TRACE_HEADER_FIELDS_REV2,
+    item_size=240,
+)
+
+rev2_extended_trace_header = StructuredDataTypeDescriptor(
+    fields=EXTENDED_TRACE_HEADER_FIELDS_REV2,
+    item_size=240,
+)
+
+rev2_trace_data = TraceSampleDescriptor(
+    format=ScalarType.IBM32,  # noqa: A003
+)
+
+
+rev2_trace = TraceDescriptor(
+    header_descriptor=rev2_trace_header,
+    extended_header_descriptor=rev2_extended_trace_header,
+    sample_descriptor=rev2_trace_data,
+)
+
+
+rev2_segy = SegyDescriptor(
+    segy_standard=SegyStandard.REV2,
+    text_file_header=rev2_textual_file_header,
+    binary_file_header=rev2_binary_file_header,
+    extended_text_header=rev2_extended_text_header,
+    trace=rev2_trace,
+    endianness=Endianness.BIG,
+)

--- a/tests/test_segy_factory.py
+++ b/tests/test_segy_factory.py
@@ -102,7 +102,8 @@ def test_binary_file_header(
         mock_segy_factory.samples_per_trace,
         mock_segy_factory.samples_per_trace,
         SEGY_FORMAT_MAP[mock_segy_factory.trace_sample_format],
-        mock_segy_factory.segy_revision.value * 256,  # type: ignore[union-attr]
+        mock_segy_factory.segy_revision.major,  # type: ignore[union-attr]
+        mock_segy_factory.segy_revision.minor,  # type: ignore[union-attr]
         0,  # fixed length trace flag
         0,  # extended text headers
     )

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -312,8 +312,10 @@ class TestSegyFileSettingsOverride:
         assert segy_file.spec.segy_standard == SegyStandard.REV1
         assert segy_file.spec.endianness == Endianness.LITTLE
         # Rev1 should have below field, but the value will be zero
-        assert "seg_y_revision" in segy_file.binary_header.dtype.names
-        assert segy_file.binary_header["seg_y_revision"] == 0
+        assert "seg_y_revision_major" in segy_file.binary_header.dtype.names
+        assert "seg_y_revision_minor" in segy_file.binary_header.dtype.names
+        assert segy_file.binary_header["seg_y_revision_major"] == 0
+        assert segy_file.binary_header["seg_y_revision_minor"] == 0
 
     @pytest.mark.parametrize("num_ext_text", [2])
     def test_ext_text_header_override(


### PR DESCRIPTION
This adds the fields for SEG-Y Rev 2.0. However, the logic to parse the file correctly has yet to be developed.

### TODO
- [X] Add Rev2 Fields
- [x] Figure out revision field parsing (see note below)
- [x] Add tests 

### NOTE
There is a weird edge case in the binary header where we define the SEG-Y format revision (bytes 3501-3502). Discovered this when working to generalize the revision format serialization for Rev2+.

In Rev1, it is defined as a 16-bit unsigned integer. Assuming the file is Rev1 and big-endian, and it is encoded as 0100 base-16; this means that the major version comes at byte 3501, and the minor version comes at byte 3502, as expected.

In Rev2 and above, this field has been split into major and minor components. The format also now supports little-endian by default. I have noticed this causes the following issues:
1.	We can’t use the Rev1 logic anymore because byte-swapping doesn’t apply to single-byte integers and will put it out of order for Rev2+ (i.e. major/minor will be flipped).
2.	If we implement the new logic (which should omit the endianness from the major/minor format revision fields because they're single byte) then it makes it incompatible with revision 1.0 with little-endian (out-of-spec) rev1 files, the major/minor revisions get swapped. 

Implemented an edge case in revision inference code. However, because of this revision fields in binary header are always flipped.. Need a cleaner way to do it.