### PR TITLE
Decoupled transformation logic from `SegyFile`

### DIFF
--- a/src/segy/accessors.py
+++ b/src/segy/accessors.py
@@ -10,6 +10,7 @@ from segy.transforms import TransformFactory
 
 if TYPE_CHECKING:
     from segy.schema import TraceDescriptor
+    from segy.transforms import Transform
 
 
 class TraceAccessor:
@@ -17,6 +18,7 @@ class TraceAccessor:
 
     trace_spec: Descriptor of TraceArray dtype.
     """
+
     def __init__(self, trace_spec: TraceDescriptor) -> None:
         self.trace_spec = trace_spec
         self.header_ibm_keys = [
@@ -24,9 +26,9 @@ class TraceAccessor:
             for field in self.trace_spec.header_descriptor.fields
             if field.dtype == ScalarType.IBM32
         ]
-        self.header_decode_transforms = []
-        self.sample_decode_transforms = []
-        self.trace_decode_transforms = []
+        self.header_decode_transforms: list[Transform] = []
+        self.sample_decode_transforms: list[Transform] = []
+        self.trace_decode_transforms: list[Transform] = []
         self._update_decoders()
 
     def _update_decoders(self) -> None:

--- a/src/segy/accessors.py
+++ b/src/segy/accessors.py
@@ -49,7 +49,7 @@ class TraceAccessor:
                 TransformFactory.create("ibm_float", "to_ieee", ["sample"])
             )
 
-        if self.header_ibm_keys:
+        if len(self.header_ibm_keys) != 0:
             self.header_decode_transforms.append(
                 TransformFactory.create(
                     "ibm_float", "to_ieee", keys=self.header_ibm_keys

--- a/src/segy/accessors.py
+++ b/src/segy/accessors.py
@@ -1,0 +1,51 @@
+"""Accessors for accessing parts of TraceArrays."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from segy.schema import ScalarType
+from segy.schema import Endianness
+from segy.transforms import TransformFactory
+
+if TYPE_CHECKING:
+    from segy.schema import TraceDescriptor
+
+
+class TraceAccessor:
+    def __init__(self, trace_spec: TraceDescriptor) -> None:
+        self.trace_spec = trace_spec
+        self.header_ibm_keys = [
+            field.name
+            for field in self.trace_spec.header_descriptor.fields
+            if field.dtype == ScalarType.IBM32
+        ]
+        self.header_decode_transforms = []
+        self.sample_decode_transforms = []
+        self.trace_decode_transforms = []
+        self._update_decoders()
+
+    def _update_decoders(self) -> None:
+        self.sample_decode_transforms.append(
+            TransformFactory.create("byte_swap", Endianness.LITTLE)
+        )
+        if self.trace_spec.sample_descriptor.format == ScalarType.IBM32:
+            self.sample_decode_transforms.append(
+                TransformFactory.create("ibm_float", "to_ieee")
+            )
+
+        self.header_decode_transforms.append(
+            TransformFactory.create("byte_swap", Endianness.LITTLE)
+        )
+        self.trace_decode_transforms.append(
+            TransformFactory.create("byte_swap", Endianness.LITTLE)
+        )
+
+        if self.header_ibm_keys:
+            self.header_decode_transforms.append(
+                TransformFactory.create("ibm_float", "to_ieee", self.header_ibm_keys)
+            )
+            self.trace_decode_transforms.append(
+                TransformFactory.create(
+                    "trace_ibm_float", "to_ieee", self.header_ibm_keys
+                )
+            )

--- a/src/segy/accessors.py
+++ b/src/segy/accessors.py
@@ -24,7 +24,7 @@ class TraceAccessor:
         self.header_ibm_keys = [
             field.name
             for field in self.trace_spec.header_descriptor.fields
-            if field.dtype == ScalarType.IBM32
+            if field.format == ScalarType.IBM32
         ]
         self.header_decode_transforms: list[Transform] = []
         self.sample_decode_transforms: list[Transform] = []

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -190,6 +190,7 @@ class IbmFloatTransform(Transform):
     def _transform(self, data: NDArray[Any]) -> NDArray[Any]:
         return self.ibm_func_map[self.direction](data)  # type: ignore
 
+
 class TraceIbmFloatTransform(Transform):
     """IBM float convert a header+array.
 
@@ -198,16 +199,30 @@ class TraceIbmFloatTransform(Transform):
         data: TraceArray to convert.
         type_to_convert: string of dtype to convert.
     """
-    def __init__(self,direction:str,type_to_convert:str, keys: list[str] | None = None, copy: TYPE_CHECKING = False) -> None:
-        super().__init__(keys, copy)
-        self.direction=direction
-        self.type_to_convert=type_to_convert
 
-    def _transform(self,data:NDArray[Any]):
-        ibm_header_keys=[name for name,field in data["header"].fields.items() if field[0].str == self.type_to_convert]
-        data.header = IbmFloatTransform(self.direction,ibm_header_keys).apply(data.header)
-        data.sample= IbmFloatTransform(self.direction,["sample"]).apply(data.sample)
+    def __init__(
+        self,
+        direction: str,
+        type_to_convert: str,
+        keys: list[str] | None = None,
+        copy: TYPE_CHECKING = False,
+    ) -> None:
+        super().__init__(keys, copy)
+        self.direction = direction
+        self.type_to_convert = type_to_convert
+
+    def _transform(self, data: NDArray[Any]):
+        ibm_header_keys = [
+            name
+            for name, field in data["header"].fields.items()
+            if field[0].str == self.type_to_convert
+        ]
+        data.header = IbmFloatTransform(self.direction, ibm_header_keys).apply(
+            data.header
+        )
+        data.sample = IbmFloatTransform(self.direction, ["sample"]).apply(data.sample)
         return data
+
 
 class TransformFactory:
     """Factory class to generate transformation strategies."""
@@ -247,5 +262,3 @@ class TransformPipeline:
         for transform in self.transforms:
             data = transform.apply(data)
         return data
-
-        

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -190,6 +190,24 @@ class IbmFloatTransform(Transform):
     def _transform(self, data: NDArray[Any]) -> NDArray[Any]:
         return self.ibm_func_map[self.direction](data)  # type: ignore
 
+class TraceIbmFloatTransform(Transform):
+    """IBM float convert a header+array.
+
+    Args:
+        direction: IBM Float convertsion direction.
+        data: TraceArray to convert.
+        type_to_convert: string of dtype to convert.
+    """
+    def __init__(self,direction:str,type_to_convert:str, keys: list[str] | None = None, copy: TYPE_CHECKING = False) -> None:
+        super().__init__(keys, copy)
+        self.direction=direction
+        self.type_to_convert=type_to_convert
+
+    def _transform(self,data:NDArray[Any]):
+        ibm_header_keys=[name for name,field in data["header"].fields.items() if field[0].str == self.type_to_convert]
+        data.header = IbmFloatTransform(self.direction,ibm_header_keys).apply(data.header)
+        data.sample= IbmFloatTransform(self.direction,["sample"]).apply(data.sample)
+        return data
 
 class TransformFactory:
     """Factory class to generate transformation strategies."""
@@ -229,3 +247,5 @@ class TransformPipeline:
         for transform in self.transforms:
             data = transform.apply(data)
         return data
+
+        

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -191,43 +191,12 @@ class IbmFloatTransform(Transform):
         return self.ibm_func_map[self.direction](data)  # type: ignore
 
 
-class TraceIbmFloatTransform(Transform):
-    """IBM float convert a header+array.
-
-    Args:
-        direction: IBM Float convertsion direction.
-        header_keys: list of keys for the header fields to convert.
-        copy: flag for copying data before converting.
-    """
-
-    def __init__(
-        self,
-        direction: str,
-        header_keys: list[str],
-        copy: bool = False,
-    ) -> None:
-        super().__init__(copy=copy)
-        self.direction = direction
-        self.header_keys = header_keys
-        self.copy = copy
-
-    def _transform(self, data: NDArray[Any]) -> NDArray[Any]:
-        data.header = TransformFactory.create(
-            "ibm_float", self.direction, self.header_keys, copy=self.copy
-        ).apply(data.header)
-        data = TransformFactory.create(
-            "ibm_float", self.direction, ["sample"], copy=self.copy
-        ).apply(data)
-        return data
-
-
 class TransformFactory:
     """Factory class to generate transformation strategies."""
 
     transform_map: dict[str, type[Transform]] = {
         "byte_swap": ByteSwapTransform,
         "ibm_float": IbmFloatTransform,
-        "trace_ibm_float": TraceIbmFloatTransform,
     }
 
     @classmethod

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1,0 +1,97 @@
+"""Tests for accessors for SegyArrays."""
+
+from __future__ import annotations
+
+import pytest
+
+from segy.accessors import TraceAccessor
+from segy.schema import Endianness
+from segy.schema import ScalarType
+from segy.schema import StructuredDataTypeDescriptor
+from segy.schema import StructuredFieldDescriptor
+from segy.schema import TraceDescriptor
+from segy.schema import TraceSampleDescriptor
+from segy.transforms import Transform
+from segy.transforms import TransformFactory
+
+
+def compare_transform(transform_a: Transform, transform_b: Transform) -> bool:
+    """Helper function for equality comparison of transforms."""
+    return all(
+        a == b
+        for a, b in [
+            (type(transform_a), type(transform_b)),
+            (transform_a.keys, transform_b.keys),
+        ]
+    )
+
+
+def compare_transform_sequence(
+    transform_a: list[Transform], transform_b: list[Transform]
+) -> bool:
+    """Helper function for equality comparison of two sequences of transforms."""
+    if len(transform_a) != len(transform_b):
+        return False
+    return all(compare_transform(a, b) for a, b in zip(transform_a, transform_b))
+
+
+@pytest.fixture(
+    params=[(ScalarType.IBM32, ScalarType.IBM32), (ScalarType.INT32, ScalarType.IBM32)]
+)
+def mock_trace_spec(
+    request: pytest.FixtureRequest,
+) -> tuple[TraceDescriptor, dict[str, list[Transform]]]:
+    """Create mock trace spec for testing and expected values for accessors."""
+    header_field_type = request.param[0]
+    sample_field_type = request.param[1]
+    trace_header_spec = StructuredDataTypeDescriptor(
+        fields=[
+            StructuredFieldDescriptor(name="h1", format=header_field_type, offset=0)
+        ],
+        item_size=4,
+        endianness=Endianness.BIG,
+        offset=0,
+    )
+    trace_sample_spec = TraceSampleDescriptor(format=sample_field_type, samples=3)
+    trace_descr = TraceDescriptor(
+        header_descriptor=trace_header_spec, sample_descriptor=trace_sample_spec
+    )
+    expected = {}
+    base_transform = TransformFactory.create("byte_swap", Endianness.LITTLE)
+    expected["header"] = (
+        [base_transform]
+        if header_field_type != ScalarType.IBM32
+        else [base_transform, TransformFactory.create("ibm_float", "to_ieee", ["h1"])]
+    )
+    expected["sample"] = (
+        [base_transform]
+        if sample_field_type != ScalarType.IBM32
+        else [base_transform, TransformFactory.create("ibm_float", "to_ieee")]
+    )
+    expected["trace"] = (
+        [base_transform]
+        if sample_field_type != ScalarType.IBM32
+        else [
+            base_transform,
+            TransformFactory.create("ibm_float", "to_ieee", ["sample"]),
+        ]
+    )
+    return trace_descr, expected
+
+
+def test_trace_accessor(
+    mock_trace_spec: tuple[TraceDescriptor, dict[str, list[Transform]]],
+) -> None:
+    """Test for trace accessor decoder transforms."""
+    trace_spec = mock_trace_spec[0]
+    expected_transforms = mock_trace_spec[1]
+    trace_accessor = TraceAccessor(trace_spec)
+    assert compare_transform_sequence(
+        trace_accessor.header_decode_transforms, expected_transforms["header"]
+    )
+    assert compare_transform_sequence(
+        trace_accessor.sample_decode_transforms, expected_transforms["sample"]
+    )
+    assert compare_transform_sequence(
+        trace_accessor.trace_decode_transforms, expected_transforms["trace"]
+    )


### PR DESCRIPTION
This PR is to move the logic for creating decoding transforms for SegyArrays accessors out of the SegyFile class. This way they are not recreated every time the accessors are used for a SegyFile instance.