### PR TITLE
Improve field management for `StructuredDataTypeDescriptor` (add/remove)

### DIFF
--- a/src/segy/schema/data_type.py
+++ b/src/segy/schema/data_type.py
@@ -232,9 +232,9 @@ class StructuredDataTypeDescriptor(BaseTypeDescriptor):
         return [field.name for field in self.fields]
 
     @property
-    def formats(self) -> list[str]:
+    def formats(self) -> list[np.dtype[Any]]:
         """Get the formats of the fields."""
-        return [field.format for field in self.fields]
+        return [field.dtype for field in self.fields]
 
     @property
     def offsets(self) -> list[int]:

--- a/src/segy/schema/data_type.py
+++ b/src/segy/schema/data_type.py
@@ -264,6 +264,9 @@ class StructuredDataTypeDescriptor(BaseTypeDescriptor):
 
         max_field = max(self.fields, key=lambda field: field.offset)
 
+        if self.item_size is None:
+            return self
+
         if max_field.offset + max_field.dtype.itemsize > self.item_size:
             msg = "Offsets exceed allowed header size."
             raise ValueError(msg)

--- a/src/segy/schema/data_type.py
+++ b/src/segy/schema/data_type.py
@@ -244,7 +244,7 @@ class StructuredDataTypeDescriptor(BaseTypeDescriptor):
     @field_validator("fields")
     @classmethod
     def ensure_no_duplicate_fields(
-        cls: StructuredDataTypeDescriptor, fields: list[StructuredFieldDescriptor]
+        cls: type[StructuredDataTypeDescriptor], fields: list[StructuredFieldDescriptor]
     ) -> list[StructuredFieldDescriptor]:
         """Check if fields are unique and error out if not."""
         name_counter = Counter(field.name for field in fields)

--- a/src/segy/schema/data_type.py
+++ b/src/segy/schema/data_type.py
@@ -259,6 +259,9 @@ class StructuredDataTypeDescriptor(BaseTypeDescriptor):
     @model_validator(mode="after")
     def ensure_offsets_in_itemsize_bounds(self) -> StructuredDataTypeDescriptor:
         """Ensure fields don't go above the allowed itemsize."""
+        if len(self.fields) == 0:
+            return self
+
         max_field = max(self.fields, key=lambda field: field.offset)
 
         if max_field.offset + max_field.dtype.itemsize > self.item_size:

--- a/tests/test_schema_data_type.py
+++ b/tests/test_schema_data_type.py
@@ -79,18 +79,20 @@ class TestStructuredDataTypeDescriptor:
         struct_descriptor.add_field(field1)
         struct_descriptor.add_field(field2)
 
+        actual_fields = dict(struct_descriptor.dtype.fields)  # type: ignore
         assert struct_descriptor.dtype.itemsize == field2.offset + field2.dtype.itemsize
         assert struct_descriptor.dtype.names == ("f1", "f2")
-        assert struct_descriptor.dtype.fields["f1"] == (field1.dtype, field1.offset)
-        assert struct_descriptor.dtype.fields["f2"] == (field2.dtype, field2.offset)
+        assert actual_fields["f1"] == (field1.dtype, field1.offset)
+        assert actual_fields["f2"] == (field2.dtype, field2.offset)
 
         # Test with overwrite.
         field2 = StructuredFieldDescriptor(name="f2", byte=11, format=ScalarType.INT32)
         struct_descriptor.add_field(field2, overwrite=True)
 
+        actual_fields = dict(struct_descriptor.dtype.fields)  # type: ignore
         assert struct_descriptor.dtype.itemsize == field2.offset + field2.dtype.itemsize
-        assert struct_descriptor.dtype.fields["f1"] == (field1.dtype, field1.offset)
-        assert struct_descriptor.dtype.fields["f2"] == (field2.dtype, field2.offset)
+        assert actual_fields["f1"] == (field1.dtype, field1.offset)
+        assert actual_fields["f2"] == (field2.dtype, field2.offset)
 
     def test_remove_structured_field(self) -> None:
         """Test field removal from structured data type."""

--- a/tests/test_schema_data_type.py
+++ b/tests/test_schema_data_type.py
@@ -114,6 +114,15 @@ class TestStructuredDataTypeDescriptor:
 class TestStructuredDataTypeDescriptorExceptions:
     """Test exceptions in structured descriptors."""
 
+    def test_duplicate_field_exception(self) -> None:
+        """Test expected failure when multiple keys are provided more than once."""
+        fields_with_duplicate = [
+            StructuredFieldDescriptor(name="f1", byte=3, format=ScalarType.INT16),
+            StructuredFieldDescriptor(name="f1", byte=9, format=ScalarType.INT16),
+        ]
+        with pytest.raises(ValueError, match="Duplicate header fields detected"):
+            StructuredDataTypeDescriptor(fields=fields_with_duplicate)
+
     def test_add_field_exception(self) -> None:
         """Test adding fields that already exists without overwrite flag."""
         struct_descriptor = StructuredDataTypeDescriptor(

--- a/tests/test_schema_data_type.py
+++ b/tests/test_schema_data_type.py
@@ -12,8 +12,8 @@ from segy.schema.data_type import StructuredDataTypeDescriptor
 from segy.schema.data_type import StructuredFieldDescriptor
 
 
-class TestBaseDataTypes:
-    """Tests for basic and structured data types and their dtype method."""
+class TestScalarTypeDescriptor:
+    """Tests for scalar data type descriptor."""
 
     @pytest.mark.parametrize(
         ("format_", "expected"),
@@ -29,6 +29,10 @@ class TestBaseDataTypes:
         """Test creating data type descriptors for `ScalarType`s."""
         dtype_descr = DataTypeDescriptor(format=format_)
         assert dtype_descr.dtype == np.dtype(expected)
+
+
+class TestStructuredDataTypeDescriptor:
+    """Tests for structured field and structured type descriptors."""
 
     @pytest.mark.parametrize("endianness", [Endianness.BIG, Endianness.LITTLE])
     @pytest.mark.parametrize(
@@ -64,6 +68,97 @@ class TestBaseDataTypes:
             assert not struct_descriptor.dtype.isnative
         if itemsize is not None:
             assert struct_descriptor.dtype.itemsize == itemsize
+
+    def test_add_structured_field(self) -> None:
+        """Test adding fields to descriptor with and without overwrite."""
+        struct_descriptor = StructuredDataTypeDescriptor(fields=[])
+
+        field1 = StructuredFieldDescriptor(name="f1", byte=3, format="int16")
+        field2 = StructuredFieldDescriptor(name="f2", byte=7, format="int16")
+
+        struct_descriptor.add_field(field1)
+        struct_descriptor.add_field(field2)
+
+        assert struct_descriptor.dtype.itemsize == field2.offset + field2.dtype.itemsize
+        assert struct_descriptor.dtype.names == ("f1", "f2")
+        assert struct_descriptor.dtype.fields["f1"] == (field1.dtype, field1.offset)
+        assert struct_descriptor.dtype.fields["f2"] == (field2.dtype, field2.offset)
+
+        # Test with overwrite.
+        field2 = StructuredFieldDescriptor(name="f2", byte=11, format="int32")
+        struct_descriptor.add_field(field2, overwrite=True)
+
+        assert struct_descriptor.dtype.itemsize == field2.offset + field2.dtype.itemsize
+        assert struct_descriptor.dtype.names == ("f1", "f2")
+        assert struct_descriptor.dtype.fields["f1"] == (field1.dtype, field1.offset)
+        assert struct_descriptor.dtype.fields["f2"] == (field2.dtype, field2.offset)
+
+    def test_remove_structured_field(self) -> None:
+        """Test field removal from structured data type."""
+        struct_descriptor = StructuredDataTypeDescriptor(
+            fields=[
+                StructuredFieldDescriptor(name="f1", byte=11, format="int8"),
+                StructuredFieldDescriptor(name="f2", byte=21, format="int16"),
+            ]
+        )
+
+        struct_descriptor.remove_field("f2")
+
+        remaining_field = struct_descriptor.fields[0]
+        expected_itemsize = remaining_field.offset + remaining_field.dtype.itemsize
+        assert struct_descriptor.itemsize == expected_itemsize
+        assert struct_descriptor.dtype.names == ("f1",)
+
+
+class TestStructuredDataTypeDescriptorExceptions:
+    """Test exceptions in structured descriptors."""
+
+    def test_add_field_exception(self) -> None:
+        """Test adding fields that already exists without overwrite flag."""
+        struct_descriptor = StructuredDataTypeDescriptor(
+            fields=[
+                StructuredFieldDescriptor(name="f1", byte=3, format="int16"),
+                StructuredFieldDescriptor(name="f2", byte=11, format="int16"),
+            ]
+        )
+
+        field = StructuredFieldDescriptor(name="f1", byte=7, format="uint8")
+        with pytest.raises(KeyError, match="f1 already exists."):
+            struct_descriptor.add_field(field)
+
+    def test_remove_field_exception(self) -> None:
+        """Test field removal from structured data type."""
+        struct_descriptor = StructuredDataTypeDescriptor(
+            fields=[
+                StructuredFieldDescriptor(name="f1", byte=11, format="int8"),
+                StructuredFieldDescriptor(name="f2", byte=21, format="int16"),
+            ]
+        )
+
+        with pytest.raises(KeyError, match="f3 does not exist."):
+            struct_descriptor.remove_field("f3")
+
+    @pytest.mark.parametrize(
+        ("names", "bytes_", "formats", "itemsize"),
+        [
+            (["f1"], [1], [ScalarType.UINT64], 4),
+            (["f1", "f2"], [1, 24], [ScalarType.UINT8, ScalarType.INT16], 16),
+        ],
+    )
+    def test_struct_size_overflow(
+        self,
+        names: list[str],
+        bytes_: list[int],
+        formats: list[ScalarType],
+        itemsize: int,
+    ) -> None:
+        """Test validation where the max field size exceeds the item size."""
+        fields = [
+            StructuredFieldDescriptor(name=name, byte=byte, format=format_)
+            for name, byte, format_ in zip(names, bytes_, formats)
+        ]
+        with pytest.raises(ValueError, match="Offsets exceed allowed header size."):
+            StructuredDataTypeDescriptor(fields=fields, item_size=itemsize)
 
 
 def test_structured_data_type_descriptor_json_validate() -> None:

--- a/tests/test_schema_data_type.py
+++ b/tests/test_schema_data_type.py
@@ -73,8 +73,8 @@ class TestStructuredDataTypeDescriptor:
         """Test adding fields to descriptor with and without overwrite."""
         struct_descriptor = StructuredDataTypeDescriptor(fields=[])
 
-        field1 = StructuredFieldDescriptor(name="f1", byte=3, format="int16")
-        field2 = StructuredFieldDescriptor(name="f2", byte=7, format="int16")
+        field1 = StructuredFieldDescriptor(name="f1", byte=3, format=ScalarType.INT16)
+        field2 = StructuredFieldDescriptor(name="f2", byte=7, format=ScalarType.INT16)
 
         struct_descriptor.add_field(field1)
         struct_descriptor.add_field(field2)
@@ -85,11 +85,10 @@ class TestStructuredDataTypeDescriptor:
         assert struct_descriptor.dtype.fields["f2"] == (field2.dtype, field2.offset)
 
         # Test with overwrite.
-        field2 = StructuredFieldDescriptor(name="f2", byte=11, format="int32")
+        field2 = StructuredFieldDescriptor(name="f2", byte=11, format=ScalarType.INT32)
         struct_descriptor.add_field(field2, overwrite=True)
 
         assert struct_descriptor.dtype.itemsize == field2.offset + field2.dtype.itemsize
-        assert struct_descriptor.dtype.names == ("f1", "f2")
         assert struct_descriptor.dtype.fields["f1"] == (field1.dtype, field1.offset)
         assert struct_descriptor.dtype.fields["f2"] == (field2.dtype, field2.offset)
 
@@ -97,8 +96,8 @@ class TestStructuredDataTypeDescriptor:
         """Test field removal from structured data type."""
         struct_descriptor = StructuredDataTypeDescriptor(
             fields=[
-                StructuredFieldDescriptor(name="f1", byte=11, format="int8"),
-                StructuredFieldDescriptor(name="f2", byte=21, format="int16"),
+                StructuredFieldDescriptor(name="f1", byte=11, format=ScalarType.INT8),
+                StructuredFieldDescriptor(name="f2", byte=21, format=ScalarType.INT16),
             ]
         )
 
@@ -117,12 +116,12 @@ class TestStructuredDataTypeDescriptorExceptions:
         """Test adding fields that already exists without overwrite flag."""
         struct_descriptor = StructuredDataTypeDescriptor(
             fields=[
-                StructuredFieldDescriptor(name="f1", byte=3, format="int16"),
-                StructuredFieldDescriptor(name="f2", byte=11, format="int16"),
+                StructuredFieldDescriptor(name="f1", byte=3, format=ScalarType.INT16),
+                StructuredFieldDescriptor(name="f2", byte=11, format=ScalarType.INT16),
             ]
         )
 
-        field = StructuredFieldDescriptor(name="f1", byte=7, format="uint8")
+        field = StructuredFieldDescriptor(name="f1", byte=7, format=ScalarType.UINT8)
         with pytest.raises(KeyError, match="f1 already exists."):
             struct_descriptor.add_field(field)
 
@@ -130,8 +129,8 @@ class TestStructuredDataTypeDescriptorExceptions:
         """Test field removal from structured data type."""
         struct_descriptor = StructuredDataTypeDescriptor(
             fields=[
-                StructuredFieldDescriptor(name="f1", byte=11, format="int8"),
-                StructuredFieldDescriptor(name="f2", byte=21, format="int16"),
+                StructuredFieldDescriptor(name="f1", byte=11, format=ScalarType.INT8),
+                StructuredFieldDescriptor(name="f2", byte=21, format=ScalarType.INT16),
             ]
         )
 

--- a/tests/test_segy_factory.py
+++ b/tests/test_segy_factory.py
@@ -52,7 +52,7 @@ def mock_segy_factory(request: pytest.FixtureRequest) -> SegyFactory:
     spec.segy_standard = test_config.segy_standard
 
     # Shrink trace headers to 16-bytes and add a few fields
-    spec.trace.header_descriptor.item_size = 16
+    spec.trace.header_descriptor.item_size = 32
     spec.trace.header_descriptor.fields = [
         StructuredFieldDescriptor(name="field1", format=ScalarType.INT8, byte=3),
         StructuredFieldDescriptor(name="field2", format=ScalarType.INT32, byte=5),


### PR DESCRIPTION
Added checks for duplicate fields and offset limits in StructuredDataTypeDescriptor. Also provided functions to add or remove fields, thereby enhancing management of field elements. These improvements ensure that fields are unique and do not exceed allowed item size, simplifying the process of adding or removing fields.

### TODO
- [X] Implement field addition
- [X] Implement field deletion
- [X] Implement properties for `names`, `offsets`, and `formats`.
- [x] Add tests
