### PR TITLE
Allow updating binary header fields in SEG-Y factory.

### DIFF
--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -86,7 +86,7 @@ class SegyFactory:
         self.spec.trace.data.samples = samples_per_trace
 
     @property
-    def trace_sample_format(self) -> ScalarType:
+    def sample_format(self) -> ScalarType:
         """Trace sample format of the SEG-Y file."""
         return self.spec.trace.data.format
 
@@ -155,7 +155,7 @@ class SegyFactory:
         bin_header["orig_sample_interval"] = self.sample_interval
         bin_header["samples_per_trace"] = self.samples_per_trace
         bin_header["orig_samples_per_trace"] = self.samples_per_trace
-        bin_header["data_sample_format"] = SEGY_FORMAT_MAP[self.trace_sample_format]
+        bin_header["data_sample_format"] = SEGY_FORMAT_MAP[self.sample_format]
 
         if update is not None:
             for key, value in update.items():
@@ -205,7 +205,7 @@ class SegyFactory:
         trace_data_spec = self.spec.trace.data
         dtype = trace_data_spec.dtype
 
-        if self.trace_sample_format == ScalarType.IBM32:
+        if self.sample_format == ScalarType.IBM32:
             dtype = np.dtype(("float32", (self.samples_per_trace,)))
 
         return np.zeros(shape=size, dtype=dtype)

--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -128,8 +128,18 @@ class SegyFactory:
 
         return text_spec.encode(text)
 
-    def create_binary_header(self) -> bytes:
+    def create_binary_header(self, update: dict[str, Any] | None = None) -> bytes:
         """Create a binary header for the SEG-Y file.
+
+        This function will create bytes representing the binary header with the
+        configuration options provided to SEG-Y factory.
+
+        The `update` parameter is a dictionary that contains binary header fields which
+        need to be modified. The function will update these fields with the values
+        specified in the update dictionary before returning the encoded bytes.
+
+        Args:
+            update: Dictionary containing binary header fields to modify.
 
         Returns:
             Bytes containing the encoded binary header, ready to write.
@@ -146,6 +156,10 @@ class SegyFactory:
         bin_header["samples_per_trace"] = self.samples_per_trace
         bin_header["orig_samples_per_trace"] = self.samples_per_trace
         bin_header["data_sample_format"] = SEGY_FORMAT_MAP[self.trace_sample_format]
+
+        if update is not None:
+            for key, value in update.items():
+                bin_header[key] = value
 
         return bin_header.tobytes()
 


### PR DESCRIPTION
The `create_binary_header` function in factory now accepts an optional `update` parameter. This dictionary contains binary header fields that need to be modified from default. The function will update these fields with the values specified in the update dictionary before returning the encoded binary header.