### PR TITLE
Fix typo in segyio -> segy aliases

### DIFF
--- a/src/segy/alias/segyio.py
+++ b/src/segy/alias/segyio.py
@@ -139,7 +139,7 @@ SEGYIO_TRACE_FIELD_MAP = {
     "ScalarTraceHeader":                      trace.Rev1.TIMES_SCALAR,
     "SourceType":                             trace.Rev1.SOURCE_TYPE_ORIENTATION,
     "SourceEnergyDirectionMantissa":          trace.Rev1.SOURCE_ENERGY_DIR_MANTISSA,
-    "SourceEnergyDirectionExponent":          trace.Rev1.SOURCE_ENERGY_DIR_MANTISSA,
+    "SourceEnergyDirectionExponent":          trace.Rev1.SOURCE_ENERGY_DIR_EXPONENT,
     "SourceMeasurementMantissa":              trace.Rev1.SOURCE_MEASUREMENT_MANTISSA,
     "SourceMeasurementExponent":              trace.Rev1.SOURCE_MEASUREMENT_EXPONENT,
     "SourceMeasurementUnit":                  trace.Rev1.SOURCE_MEASUREMENT_UNIT,


### PR DESCRIPTION
The `SourceEnergyDirectionExponent` field was incorrectly mapped to `trace.Rev1.SOURCE_ENERGY_DIR_MANTISSA`. This PR fixes that.