### PR TITLE
Streamline endianness inference

### DIFF
--- a/src/segy/config.py
+++ b/src/segy/config.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from pydantic_settings import BaseSettings
 from pydantic_settings import SettingsConfigDict
 
-from segy.schema import Endianness
+from segy.schema import Endianness  # noqa: TCH001
 
 
 class SegyBaseSettings(BaseSettings):
@@ -45,8 +45,8 @@ class SegySettings(SegyBaseSettings):
         default_factory=BinaryHeaderSettings,
         description="Overrides for binary file header settings.",
     )
-    endianness: Endianness = Field(
-        default=Endianness.BIG,
+    endianness: Endianness | None = Field(
+        default=None,
         description="Override the inferred endianness of the file.",
     )
     storage_options: dict[str, Any] = Field(

--- a/src/segy/indexing.py
+++ b/src/segy/indexing.py
@@ -12,7 +12,6 @@ from fsspec.utils import merge_offset_ranges
 
 from segy.arrays import HeaderArray
 from segy.arrays import TraceArray
-from segy.config import SegySettings
 from segy.transforms import TransformPipeline
 
 if TYPE_CHECKING:
@@ -103,7 +102,6 @@ class AbstractIndexer(ABC):
         url: A string representing the URL of the file.
         spec: An instance of BaseDataType.
         max_value: An integer representing the maximum value of the index.
-        settings: Optional parsing settings.
         transform_pipeline: The transforms pipeline to apply for decoding.
     """
 
@@ -115,14 +113,12 @@ class AbstractIndexer(ABC):
         url: str,
         spec: BaseDataType,
         max_value: int,
-        settings: SegySettings | None = None,
         transform_pipeline: TransformPipeline | None = None,
     ):
         self.fs = fs
         self.url = url
         self.spec = spec
         self.max_value = max_value
-        self.settings = SegySettings() if settings is None else settings
 
         self.transform_pipeline = (
             TransformPipeline() if transform_pipeline is None else transform_pipeline

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -314,6 +314,14 @@ class TestSegyFileSettingsOverride:
             endianness=Endianness.BIG,
         )
 
+        # Ensure still infer correctly if endian not provided
+        settings_dict = {"binary": {"revision": 1.0}}
+        settings = SegySettings.model_validate(settings_dict)
+        segy_file = SegyFile(test_config.uri, settings=settings)
+
+        assert segy_file.spec.endianness == Endianness.BIG
+
+        # Now ensure overriding both
         settings_dict = {"binary": {"revision": 1.0}, "endianness": "little"}
         settings = SegySettings.model_validate(settings_dict)
         segy_file = SegyFile(test_config.uri, settings=settings)

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -154,6 +154,14 @@ class TestSegyFile:
         # Check if JSON-able dict representation is valid
         assert segy_file.spec._repr_json_() == segy_file.spec.model_dump(mode="json")
 
+        # Test the other case where we exactly specify the spec.
+        spec_expected = get_segy_standard(standard)
+        spec_expected.endianness = endianness
+        spec_expected.trace.data.format = sample_format
+        segy_file_expected = SegyFile(test_config.uri, spec=spec_expected)
+
+        assert segy_file_expected.spec == segy_file.spec
+
     def test_text_file_header(
         self, mock_filesystem: MemoryFileSystem, default_text: str
     ) -> None:

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -323,15 +323,15 @@ class TestSegyFileSettingsOverride:
         )
 
         # Ensure still infer correctly if endian not provided
-        settings_dict = {"binary": {"revision": 1.0}}
-        settings = SegySettings.model_validate(settings_dict)
+        settings_dict_rev_only = {"binary": {"revision": 1.0}}
+        settings = SegySettings.model_validate(settings_dict_rev_only)
         segy_file = SegyFile(test_config.uri, settings=settings)
 
         assert segy_file.spec.endianness == Endianness.BIG
 
         # Now ensure overriding both
-        settings_dict = {"binary": {"revision": 1.0}, "endianness": "little"}
-        settings = SegySettings.model_validate(settings_dict)
+        settings_dict_both = {"binary": {"revision": 1.0}, "endianness": "little"}
+        settings = SegySettings.model_validate(settings_dict_both)
         segy_file = SegyFile(test_config.uri, settings=settings)
 
         assert segy_file.spec.segy_standard == SegyStandard.REV1


### PR DESCRIPTION
The endianness inference in edge cases or overrides were clunky. Now made it more streamlined and automated.