### PR TITLE
Improve data getter functionality

### DIFF
--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 
 from segy.indexing import bounds_check
@@ -31,7 +32,7 @@ class TestBoundsCheckIndices:
     )
     def test_in_bounds(self, indices: list[int], size: int) -> None:
         """Test the case where indices are in bounds."""
-        bounds_check(indices, size, "trace")
+        bounds_check(np.asarray(indices), size, "trace")
 
     @pytest.mark.parametrize(
         ("indices", "size"),
@@ -43,7 +44,7 @@ class TestBoundsCheckIndices:
     def test_out_of_bounds(self, indices: list[int], size: int) -> None:
         """Test the case where indices out of bounds or negative."""
         with pytest.raises(IndexError, match="out of bounds"):
-            bounds_check(indices, size, "")
+            bounds_check(np.asarray(indices), size, "")
 
 
 class TestMergeCatFile:

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -263,6 +263,18 @@ class TestSegyFile:
         assert_array_equal(traces.header, test_config.expected_headers)
         assert_array_almost_equal(traces.sample, test_config.expected_samples)
 
+        # Test random access
+        index = [0, 2, 4]
+        traces = segy_file.trace[index]
+        assert_array_equal(traces.header, test_config.expected_headers[index])
+        assert_array_almost_equal(traces.sample, test_config.expected_samples[index])
+
+        # Test reverse order random access
+        index = [5, 3, 0]
+        traces = segy_file.trace[index]
+        assert_array_equal(traces.header, test_config.expected_headers[index])
+        assert_array_almost_equal(traces.sample, test_config.expected_samples[index])
+
 
 class TestSegyFileExceptions:
     """Test exceptions for SegyFile."""


### PR DESCRIPTION
**tl;dr**
* Return traces/headers etc., in user-requested order.
* Allow ndarray indexing
* Consolidate int, ndarray, and list indexing to a single function

If users asked for traces in descending or random order, the read optimizations returned traces/headers in an unexpectedly sorted order. We now return in the same order the user asked for.


