### PR TITLE
Interpret SEG-Y revision in binary header

### DIFF
--- a/src/segy/constants.py
+++ b/src/segy/constants.py
@@ -1,0 +1,3 @@
+"""Constant values used in SEG_Y."""
+
+REV1_BASE16 = 0x01_00  # hex -> int = 256

--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -104,8 +104,11 @@ class SegyFactory:
         return cast(int, self.spec.trace.data.samples)
 
     @property
-    def segy_revision(self) -> SegyStandard | None:
+    def segy_revision(self) -> SegyStandard:
         """Revision of the SEG-Y file."""
+        if self.spec.segy_standard is None:
+            return SegyStandard.REV0
+
         return self.spec.segy_standard
 
     def create_textual_header(self, text: str | None = None) -> bytes:
@@ -148,10 +151,8 @@ class SegyFactory:
         binary_spec = self.spec.binary_header
         bin_header = HeaderArray(np.zeros(shape=1, dtype=binary_spec.dtype))
 
-        if self.segy_revision is None:
-            pass
-        elif self.segy_revision == SegyStandard.REV1:
-            bin_header["segy_revision"] = REV1_BASE16  # base-16
+        if self.segy_revision == SegyStandard.REV1:
+            bin_header["segy_revision"] = REV1_BASE16
         elif self.segy_revision >= SegyStandard.REV2:
             minor, major = np.modf(self.segy_revision)
             bin_header["segy_revision_major"] = major

--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from segy.arrays import HeaderArray
 from segy.arrays import TraceArray
+from segy.constants import REV1_BASE16
 from segy.schema.base import Endianness
 from segy.schema.format import ScalarType
 from segy.schema.segy import SegyStandard
@@ -150,10 +151,10 @@ class SegyFactory:
         if self.segy_revision is None:
             pass
         elif self.segy_revision == SegyStandard.REV1:
-            bin_header["segy_revision"] = 256  # base-16
+            bin_header["segy_revision"] = REV1_BASE16  # base-16
         elif self.segy_revision >= SegyStandard.REV2:
             minor, major = np.modf(self.segy_revision)
-            bin_header["segy_revision"] = major
+            bin_header["segy_revision_major"] = major
             bin_header["segy_revision_minor"] = minor
 
         bin_header["sample_interval"] = self.sample_interval

--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -147,9 +147,12 @@ class SegyFactory:
         binary_spec = self.spec.binary_header
         bin_header = HeaderArray(np.zeros(shape=1, dtype=binary_spec.dtype))
 
-        rev0 = self.segy_revision == SegyStandard.REV0
-        if self.segy_revision is not None and not rev0:
-            bin_header["segy_revision"] = self.segy_revision.value * 256
+        if self.segy_revision == SegyStandard.REV1:
+            bin_header["segy_revision"] = 256  # base-16
+        elif self.segy_revision >= SegyStandard.REV2:
+            minor, major = np.modf(self.segy_revision.value)
+            bin_header["segy_revision"] = major
+            bin_header["segy_revision_minor"] = minor
 
         bin_header["sample_interval"] = self.sample_interval
         bin_header["orig_sample_interval"] = self.sample_interval

--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -147,10 +147,12 @@ class SegyFactory:
         binary_spec = self.spec.binary_header
         bin_header = HeaderArray(np.zeros(shape=1, dtype=binary_spec.dtype))
 
-        if self.segy_revision == SegyStandard.REV1:
+        if self.segy_revision is None:
+            pass
+        elif self.segy_revision == SegyStandard.REV1:
             bin_header["segy_revision"] = 256  # base-16
         elif self.segy_revision >= SegyStandard.REV2:
-            minor, major = np.modf(self.segy_revision.value)
+            minor, major = np.modf(self.segy_revision)
             bin_header["segy_revision"] = major
             bin_header["segy_revision_minor"] = minor
 

--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -154,7 +154,7 @@ class SegyFactory:
         if self.segy_revision == SegyStandard.REV1:
             bin_header["segy_revision"] = REV1_BASE16
         elif self.segy_revision >= SegyStandard.REV2:
-            minor, major = np.modf(self.segy_revision)
+            minor, major = np.modf(self.segy_revision.value)
             bin_header["segy_revision_major"] = major
             bin_header["segy_revision_minor"] = minor
 

--- a/src/segy/file.py
+++ b/src/segy/file.py
@@ -239,6 +239,9 @@ class SegyFile:
             little_endian = TransformFactory.create("byte_swap", Endianness.LITTLE)
             transforms.add_transform(little_endian)
 
+        interpret_revision = TransformFactory.create("segy_revision")
+        transforms.add_transform(interpret_revision)
+
         return HeaderArray(transforms.apply(bin_hdr))
 
     def _update_spec(self) -> None:

--- a/src/segy/file.py
+++ b/src/segy/file.py
@@ -76,7 +76,7 @@ def infer_endianness(
         bin_spec.endianness = endianness
         bin_hdr = np.frombuffer(buffer, dtype=bin_spec.dtype)
 
-        revision = bin_hdr["segy_revision"].item() / 256.0
+        revision = bin_hdr["segy_revision"].item() / 256.0  # base-16
         sample_increment = bin_hdr["sample_interval"].item()
         sample_format_int = bin_hdr["data_sample_format"].item()
 

--- a/src/segy/file.py
+++ b/src/segy/file.py
@@ -13,6 +13,7 @@ from fsspec.core import url_to_fs
 from segy.accessors import TraceAccessor
 from segy.arrays import HeaderArray
 from segy.config import SegySettings
+from segy.constants import REV1_BASE16
 from segy.exceptions import EndiannessInferenceError
 from segy.indexing import DataIndexer
 from segy.indexing import HeaderIndexer
@@ -76,7 +77,7 @@ def infer_endianness(
         bin_spec.endianness = endianness
         bin_hdr = np.frombuffer(buffer, dtype=bin_spec.dtype)
 
-        revision = bin_hdr["segy_revision"].item() / 256.0  # base-16
+        revision = bin_hdr["segy_revision"].item() / REV1_BASE16
         sample_increment = bin_hdr["sample_interval"].item()
         sample_format_int = bin_hdr["data_sample_format"].item()
 

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -211,9 +211,6 @@ class SegyRevisionTransform(Transform):
 
         major = SegyStandard(data["segy_revision"] // 256)
         data["segy_revision"] = major
-        if major >= SegyStandard.REV2:
-            msg = "Revision interpretation for Rev2+ is not implemented."
-            raise NotImplementedError(msg)
 
         return data
 

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -206,7 +206,7 @@ class SegyRevisionTransform(Transform):
 
     def transform(self, data: NDArray[Any]) -> NDArray[Any]:
         """Assume Rev1 parsed major and update minor if major is 2."""
-        if data["segy_revision"] == 0:
+        if "segy_revision" not in data.dtype.names:
             return data
 
         major = SegyStandard(data["segy_revision"] // 256)

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -208,7 +208,8 @@ class SegyRevisionTransform(Transform):
 
     def transform(self, data: NDArray[Any]) -> NDArray[Any]:
         """Parse SEG-Y standard from binary header."""
-        if "segy_revision" not in data.dtype.names:  # Rev0
+        if data.dtype.names is not None and "segy_revision" not in data.dtype.names:
+            # Rev0
             return data
 
         # Rev1 needs special treatment.

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -206,6 +206,9 @@ class SegyRevisionTransform(Transform):
 
     def transform(self, data: NDArray[Any]) -> NDArray[Any]:
         """Assume Rev1 parsed major and update minor if major is 2."""
+        if data["segy_revision"] == 0:
+            return data
+
         major = SegyStandard(data["segy_revision"] // 256)
         data["segy_revision"] = major
         if major >= SegyStandard.REV2:

--- a/src/segy/transforms.py
+++ b/src/segy/transforms.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from segy.constants import REV1_BASE16
 from segy.schema import SegyStandard
 from segy.schema.base import Endianness
 
@@ -17,8 +18,6 @@ if TYPE_CHECKING:
     from numpy._typing._dtype_like import _DTypeDict
     from numpy.typing import DTypeLike
     from numpy.typing import NDArray
-
-REV1_INT16 = 256
 
 
 def get_endianness(data: NDArray[Any]) -> Endianness:
@@ -209,13 +208,12 @@ class SegyRevisionTransform(Transform):
     def transform(self, data: NDArray[Any]) -> NDArray[Any]:
         """Parse SEG-Y standard from binary header."""
         if data.dtype.names is not None and "segy_revision" not in data.dtype.names:
-            # Rev0
-            return data
+            return data  # rev0, no-op
 
         # Rev1 needs special treatment.
         # Rev1 is 16-bit with Q-point between the bytes. That means
         # SEG-Y 1.0 is written as 00000001 00000000 in binary, 256 in base-2.
-        if data["segy_revision"] == REV1_INT16:  # noqa: PLR2004
+        if data["segy_revision"] == REV1_BASE16:
             data["segy_revision"] = SegyStandard.REV1
 
         # Rev2 doesn't need special treatment because it splits into

--- a/tests/test_segy_factory.py
+++ b/tests/test_segy_factory.py
@@ -25,13 +25,14 @@ from segy.standards.minimal import minimal_segy
 class SegyFactoryTestConfig:
     """Dataclass to configure common test patterns."""
 
-    segy_standard: SegyStandard
+    segy_standard: SegyStandard | None
     endianness: Endianness
     sample_interval: int
     samples_per_trace: int
 
 
 SEGY_FACTORY_TEST_CONFIGS = [
+    SegyFactoryTestConfig(None, Endianness.BIG, 2000, 51),
     SegyFactoryTestConfig(SegyStandard.REV0, Endianness.BIG, 2000, 51),
     SegyFactoryTestConfig(SegyStandard.REV1, Endianness.LITTLE, 3000, 1),
     SegyFactoryTestConfig(SegyStandard.REV0, Endianness.BIG, 5000, 10),

--- a/tests/test_segy_factory.py
+++ b/tests/test_segy_factory.py
@@ -128,7 +128,7 @@ class TestBinaryFileHeader:
             mock_segy_factory.samples_per_trace,
             mock_segy_factory.samples_per_trace,
             SEGY_FORMAT_MAP[mock_segy_factory.sample_format],
-            mock_segy_factory.segy_revision.value * 256,  # type: ignore[union-attr]
+            mock_segy_factory.segy_revision.value * 256,
             0,  # fixed length trace flag
             0,  # extended text headers
         )
@@ -152,7 +152,7 @@ class TestBinaryFileHeader:
             mock_segy_factory.samples_per_trace,
             mock_segy_factory.samples_per_trace,
             SEGY_FORMAT_MAP[mock_segy_factory.sample_format],
-            mock_segy_factory.segy_revision.value * 256,  # type: ignore[union-attr]
+            mock_segy_factory.segy_revision.value * 256,
             1,  # fixed length trace flag
             2,  # extended text headers
         )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Any
+from typing import cast
 
 import numpy as np
 import pytest
@@ -16,6 +16,8 @@ from segy.transforms import TransformFactory
 from segy.transforms import TransformPipeline
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from numpy.typing import NDArray
 
 
@@ -154,20 +156,22 @@ class TestRevisionTransform:
         transform = TransformFactory.create("segy_revision")
         transformed_bin_header = transform.apply(bin_header)
 
+        header_fields = cast(tuple[str], transformed_bin_header.dtype.names)
+
         if revision == SegyStandard.REV0:
-            assert "segy_revision" not in transformed_bin_header.dtype.names
-            assert "segy_revision_major" not in transformed_bin_header.dtype.names
-            assert "segy_revision_minor" not in transformed_bin_header.dtype.names
+            assert "segy_revision" not in header_fields
+            assert "segy_revision_major" not in header_fields
+            assert "segy_revision_minor" not in header_fields
 
         elif revision == SegyStandard.REV1:
             assert transformed_bin_header["segy_revision"].squeeze() == major
-            assert "segy_revision_major" not in transformed_bin_header.dtype.names
-            assert "segy_revision_minor" not in transformed_bin_header.dtype.names
+            assert "segy_revision_major" not in header_fields
+            assert "segy_revision_minor" not in header_fields
 
         elif revision == SegyStandard.REV2:
             assert transformed_bin_header["segy_revision_major"].squeeze() == major
             assert transformed_bin_header["segy_revision_minor"].squeeze() == minor
-            assert "segy_revision" not in transformed_bin_header.dtype.names
+            assert "segy_revision" not in header_fields
 
 
 class TestTransformPipeline:


### PR DESCRIPTION
Introduced a new `SegyRevisionTransform` class to interpret the SEG-Y revision field in the binary header. This transform has been added to the `transform_map` and applied in the SEG-Y file processing pipeline. The code raises a `NotImplementedError` for SEG-Y revisions 2 and above.

- [X] Add forward transform (read).
- [x] Add backward transform (factory).
- [x] Add unit tests.