### PR TITLE
Fix incorrect variable length string data type creation

### DIFF
--- a/src/segy/schema/format.py
+++ b/src/segy/schema/format.py
@@ -31,9 +31,15 @@ class ScalarType(StrEnum):
     @property
     def char(self) -> str:
         """Returns the numpy character code for a given data type string."""
+        # IBM Float
         if self.value == "ibm32":
             return np.sctype2char("uint32")  # noqa: NPY201
 
+        # String
+        if self.value.startswith("S"):
+            return self.value
+
+        # Everything Else
         return np.sctype2char(str(self.value))  # noqa: NPY201
 
 

--- a/src/segy/schema/format.py
+++ b/src/segy/schema/format.py
@@ -36,8 +36,8 @@ class ScalarType(StrEnum):
             return np.sctype2char("uint32")  # noqa: NPY201
 
         # String
-        if self.value.startswith("S"):
-            return self.value
+        if self.name.startswith("STRING"):
+            return str(self.value)
 
         # Everything Else
         return np.sctype2char(str(self.value))  # noqa: NPY201


### PR DESCRIPTION
Previously, the method did not account for string length. This change includes a condition to directly return string types without conversion. Additionally, comments were added for clarity on different data type sections.