### PR TITLE
Revert "Bump crazy-max/ghaction-github-labeler from 5.0.0 to 5.1.0"

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.1.0
+        uses: crazy-max/ghaction-github-labeler@v5.0.0
         with:
           yaml-file: .github/labels.yaml
           skip-delete: true


### PR DESCRIPTION
Reverts TGSAI/segy#205. It broke CI.