### PR TITLE
Fix indexing issues when duplicate indices are present.

### DIFF
--- a/docs/tutorials/quickstart.ipynb
+++ b/docs/tutorials/quickstart.ipynb
@@ -376,7 +376,6 @@
     "\n",
     "rng = default_rng()\n",
     "indices = rng.choice(sgy.num_traces, size=5_000, replace=False)\n",
-    "indices.sort()\n",
     "\n",
     "traces = sgy.trace[indices]"
    ]

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -289,6 +289,12 @@ class TestSegyFile:
         assert_array_equal(traces.header, test_config.expected_headers[index])
         assert_array_almost_equal(traces.sample, test_config.expected_samples[index])
 
+        # Test random access with duplicates
+        index = [5, 3, 0, 5, 5, 3]
+        traces = segy_file.trace[index]
+        assert_array_equal(traces.header, test_config.expected_headers[index])
+        assert_array_almost_equal(traces.sample, test_config.expected_samples[index])
+
 
 class TestSegyFileExceptions:
     """Test exceptions for SegyFile."""


### PR DESCRIPTION
If we requested duplicate indices in traces (e.g., ` [0, 1, 2, 3, 1]`), the I/O layer would not fetch them twice but drop them. When re-sorting to the original order, we were missing values, causing an error.

Now, it is ensured that duplicates are found and reconstructed while throwing a warning.