### PR TITLE
Ensure sample format code value gets extracted from Numpy struct

### DIFF
--- a/src/segy/file.py
+++ b/src/segy/file.py
@@ -213,7 +213,7 @@ class SegyFile:
                 )
                 ext_text_header_spec.count = settings_num_ext_text
 
-        sample_format_value = self.binary_header["data_sample_format"]
+        sample_format_value = self.binary_header["data_sample_format"].item()
         data_sample_format_code = DataSampleFormatCode(sample_format_value)
         sample_format = ScalarType[data_sample_format_code.name]
 


### PR DESCRIPTION
Python 3.13.0 has a bug where it can't compare singleton numpy arrays in Enum construction. It was fixed in 3.13.1; however, we should still support 3.13.0. 

In this fix we ensure the singleton item is extracted with `.item()` method, consistent with other value extractions in the same function.

This was noticed due to documentation build errors on readthedocs with 3.13.0.