### PR TITLE
Add a flag to request raw bytes in data indexers

### DIFF
--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -122,7 +122,8 @@ class HeaderArray(SegyArray):
 
     def __getitem__(self, item: Any) -> Any:  # noqa: ANN401
         """Special getitem where we normalize header keys. Pass along to numpy."""
-        if self.dtype.kind == "V":
+        if self.dtype.kind == "V" and self.dtype.names is None:
+            # edge case for raw arrays when its void and no fields
             return super().__getitem__(item)
 
         if self.dtype.names is None:  # to keep mypy happy
@@ -144,7 +145,8 @@ class HeaderArray(SegyArray):
 
     def __setitem__(self, key: Any, value: Any) -> None:  # noqa: ANN401
         """Special getitem where we normalize header keys. Pass along to numpy."""
-        if self.dtype.kind == "V":
+        if self.dtype.kind == "V" and self.dtype.names is None:
+            # edge case for raw arrays when its void and no fields
             super().__setitem__(key, value)
 
         if self.dtype.names is None:  # to keep mypy happy

--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -118,8 +118,8 @@ class HeaderArray(SegyArray):
 
     def __getitem__(self, item: Any) -> Any:  # noqa: ANN401
         """Special getitem where we normalize header keys. Pass along to numpy."""
-        if self.dtype.kind == "V" and self.dtype.names is None:
-            # edge case for raw arrays when its void and no fields
+        if self.dtype.names is None:
+            # edge case for raw arrays when it has no fields
             return super().__getitem__(item)
 
         if isinstance(item, str) and item in self.dtype.names:
@@ -137,15 +137,16 @@ class HeaderArray(SegyArray):
 
     def __setitem__(self, key: Any, value: Any) -> None:  # noqa: ANN401
         """Special getitem where we normalize header keys. Pass along to numpy."""
-        if self.dtype.kind == "V" and self.dtype.names is None:
-            # edge case for raw arrays when its void and no fields
-            super().__setitem__(key, value)
-
-        if isinstance(key, str) and key in self.dtype.names:
+        if self.dtype.names is None:
+            # edge case for raw arrays when it has no fields
             super().__setitem__(key, value)
             return
 
         if isinstance(key, str):
+            if key in self.dtype.names:
+                super().__setitem__(key, value)
+                return
+
             key = self._normalize_and_validate_keys(key)
 
         elif isinstance(key, list) and all(isinstance(i, str) for i in key):

--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -107,12 +107,12 @@ class HeaderArray(SegyArray):
         if isinstance(key, str):
             original_key = copy(key)
             key = normalize_key(key)
-            validate_key(key, original_key, self.dtype.names)
+            validate_key(key, original_key, self.dtype.names)  # type: ignore[arg-type]
         elif isinstance(key, list):
             original_keys = copy(key)
             key = [normalize_key(k) for k in key]
             for k, orig_k in zip(key, original_keys, strict=True):
-                validate_key(k, orig_k, self.dtype.names)
+                validate_key(k, orig_k, self.dtype.names)  # type: ignore[arg-type]
 
         return key
 

--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -122,6 +122,9 @@ class HeaderArray(SegyArray):
 
     def __getitem__(self, item: Any) -> Any:  # noqa: ANN401
         """Special getitem where we normalize header keys. Pass along to numpy."""
+        if self.dtype.kind == "V":
+            return super().__getitem__(item)
+
         if self.dtype.names is None:  # to keep mypy happy
             msg = f"{self.__class__.__name__} can only work on structured arrays."
             raise ValueError(msg)
@@ -141,6 +144,9 @@ class HeaderArray(SegyArray):
 
     def __setitem__(self, key: Any, value: Any) -> None:  # noqa: ANN401
         """Special getitem where we normalize header keys. Pass along to numpy."""
+        if self.dtype.kind == "V":
+            super().__setitem__(key, value)
+
         if self.dtype.names is None:  # to keep mypy happy
             msg = f"{self.__class__.__name__} can only work on structured arrays."
             raise ValueError(msg)

--- a/src/segy/arrays.py
+++ b/src/segy/arrays.py
@@ -104,10 +104,6 @@ class HeaderArray(SegyArray):
         return DataFrame.from_records(self)
 
     def _normalize_and_validate_keys(self, key: str | list[str]) -> str | list[str]:
-        if self.dtype.names is None:  # to keep mypy happy
-            msg = f"{self.__class__.__name__} can only work on structured arrays."
-            raise ValueError(msg)
-
         if isinstance(key, str):
             original_key = copy(key)
             key = normalize_key(key)
@@ -125,10 +121,6 @@ class HeaderArray(SegyArray):
         if self.dtype.kind == "V" and self.dtype.names is None:
             # edge case for raw arrays when its void and no fields
             return super().__getitem__(item)
-
-        if self.dtype.names is None:  # to keep mypy happy
-            msg = f"{self.__class__.__name__} can only work on structured arrays."
-            raise ValueError(msg)
 
         if isinstance(item, str) and item in self.dtype.names:
             return super().__getitem__(item)
@@ -148,10 +140,6 @@ class HeaderArray(SegyArray):
         if self.dtype.kind == "V" and self.dtype.names is None:
             # edge case for raw arrays when its void and no fields
             super().__setitem__(key, value)
-
-        if self.dtype.names is None:  # to keep mypy happy
-            msg = f"{self.__class__.__name__} can only work on structured arrays."
-            raise ValueError(msg)
 
         if isinstance(key, str) and key in self.dtype.names:
             super().__setitem__(key, value)

--- a/src/segy/indexing.py
+++ b/src/segy/indexing.py
@@ -144,7 +144,9 @@ class AbstractIndexer(ABC):
         """Apply transforms to the data after decoding."""
         return self.transform_pipeline.apply(data)
 
-    def __getitem__(self, item: int | list[int] | NDArray[IntDType] | slice) -> Any:  # noqa: ANN401
+    def _normalize_and_validate_query(
+        self, item: int | list[int] | NDArray[IntDType] | slice
+    ) -> NDArray[IntDType]:
         """Operator for integers, lists, and slices with bounds checking."""
         if isinstance(item, slice):
             if item.step == 0:
@@ -166,6 +168,11 @@ class AbstractIndexer(ABC):
             msg = "Couldn't parse request. Please ensure it is a valid index."
             raise IndexError(msg)
 
+        return indices
+
+    def __getitem__(self, item: int | list[int] | NDArray[IntDType] | slice) -> Any:  # noqa: ANN401
+        """Operator for integers, lists, and slices with bounds checking."""
+        indices = self._normalize_and_validate_query(item)
         data = self.fetch(indices)
         return self.post_process(data)
 

--- a/src/segy/indexing.py
+++ b/src/segy/indexing.py
@@ -158,7 +158,7 @@ class AbstractIndexer(ABC):
         """Apply transforms to the data after decoding."""
         return self.transform_pipeline.apply(data)
 
-    def _normalize_and_validate_query(
+    def normalize_and_validate_query(
         self, item: int | list[int] | NDArray[IntDType] | slice
     ) -> NDArray[IntDType]:
         """Operator for integers, lists, and slices with bounds checking."""
@@ -186,7 +186,7 @@ class AbstractIndexer(ABC):
 
     def __getitem__(self, item: int | list[int] | NDArray[IntDType] | slice) -> Any:  # noqa: ANN401
         """Operator for integers, lists, and slices with bounds checking."""
-        indices = self._normalize_and_validate_query(item)
+        indices = self.normalize_and_validate_query(item)
         data = self.fetch(indices)
         return self.post_process(data)
 

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -258,7 +258,7 @@ class TestSegyFile:
         trace_offset = segy_file.spec.trace.offset
         trace_buffer_size = segy_file.spec.trace.dtype.itemsize
         for trc_idx in range(segy_file.num_traces):
-            start = trace_offset + trc_idx * trace_buffer_size
+            start = trace_offset + trc_idx * trace_buffer_size  # type: ignore[operator]
             stop = start + header_buffer_size
             expected_bytes += segy_file.fs.read_bytes(segy_file.url, start, stop)
         assert actual_bytes == expected_bytes, "Raw bytes do not match expected."
@@ -296,7 +296,7 @@ class TestSegyFile:
         header_buffer_size = segy_file.spec.trace.header.dtype.itemsize
         trace_buffer_size = segy_file.spec.trace.dtype.itemsize
         for trc_idx in range(segy_file.num_traces):
-            start = trace_offset + trc_idx * trace_buffer_size + header_buffer_size
+            start = trace_offset + trc_idx * trace_buffer_size + header_buffer_size  # type: ignore[operator]
             stop = start + sample_buffer_size
             expected_bytes += segy_file.fs.read_bytes(segy_file.url, start, stop)
         assert actual_bytes == expected_bytes, "Raw bytes do not match expected."
@@ -354,8 +354,9 @@ class TestSegyFile:
         # Test raw access bytes
         actual_bytes = buffer.tobytes()
         expected_bytes = b""
+        trace_offset = segy_file.spec.trace.offset
         for trc_idx in index:
-            start = segy_file.spec.trace.offset + trc_idx * trace_buffer_size
+            start = trace_offset + trc_idx * trace_buffer_size  # type: ignore[operator]
             stop = start + trace_buffer_size
             expected_bytes += segy_file.fs.read_bytes(segy_file.url, start, stop)
         assert actual_bytes == expected_bytes, "Raw bytes do not match expected."

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -252,6 +252,8 @@ class TestSegyFile:
         assert buffer.nbytes == header_buffer_size * segy_file.num_traces
         assert buffer.dtype == np.dtype((np.void, header_buffer_size))
 
+        segy_file.header[:2]["trace_weighting_factor"]
+
         # Test raw access bytes
         actual_bytes = buffer.tobytes()
         expected_bytes = b""

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -344,12 +344,12 @@ class TestSegyFile:
         assert_array_almost_equal(traces.sample, test_config.expected_samples[index])
 
         # Test raw access reusing the complex random access with duplicates
-        index = segy_file.trace.normalize_and_validate_query(index)
-        buffer = segy_file.trace.fetch(index, raw=True)
+        index_np = segy_file.trace.normalize_and_validate_query(index)
+        buffer = segy_file.trace.fetch(index_np, raw=True)
         trace_buffer_size = segy_file.spec.trace.dtype.itemsize
         assert buffer.nbytes == trace_buffer_size * len(index)
         assert buffer.dtype == np.dtype((np.void, trace_buffer_size))
-        assert buffer.shape == index.shape
+        assert buffer.shape == index_np.shape
 
         # Test raw access bytes
         actual_bytes = buffer.tobytes()

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -245,6 +245,25 @@ class TestSegyFile:
 
         assert_array_equal(segy_file.header[:], test_config.expected_headers)
 
+        # Test raw access
+        index = segy_file.header.normalize_and_validate_query(slice(None))
+        buffer = segy_file.header.fetch(index, raw=True)
+        header_buffer_size = segy_file.spec.trace.header.dtype.itemsize
+        assert buffer.nbytes == header_buffer_size * segy_file.num_traces
+        assert buffer.dtype == np.dtype((np.void, header_buffer_size))
+
+        # Test raw access bytes
+        actual_bytes = buffer.tobytes()
+        expected_bytes = b""
+        trace_offset = segy_file.spec.trace.offset
+        header_buffer_size = segy_file.spec.trace.header.dtype.itemsize
+        trace_buffer_size = segy_file.spec.trace.dtype.itemsize
+        for trc_idx in range(segy_file.num_traces):
+            start = trace_offset + trc_idx * trace_buffer_size
+            stop = start + header_buffer_size
+            expected_bytes += segy_file.fs.read_bytes(segy_file.url, start, stop)
+        assert actual_bytes == expected_bytes, "Raw bytes do not match expected."
+
     @pytest.mark.parametrize("endianness", [Endianness.BIG, Endianness.LITTLE])
     @pytest.mark.parametrize("sample_format", [ScalarType.IBM32, ScalarType.FLOAT32])
     def test_trace_sample_accessor(
@@ -263,6 +282,25 @@ class TestSegyFile:
         segy_file = SegyFile(test_config.uri)
 
         assert_array_almost_equal(segy_file.sample[:], test_config.expected_samples)
+
+        # Test raw access
+        index = segy_file.sample.normalize_and_validate_query(slice(None))
+        buffer = segy_file.sample.fetch(index, raw=True)
+        sample_buffer_size = segy_file.spec.trace.data.dtype.itemsize
+        assert buffer.nbytes == sample_buffer_size * segy_file.num_traces
+        assert buffer.dtype == np.dtype((np.void, sample_buffer_size))
+
+        # Test raw access bytes
+        actual_bytes = buffer.tobytes()
+        expected_bytes = b""
+        trace_offset = segy_file.spec.trace.offset
+        header_buffer_size = segy_file.spec.trace.header.dtype.itemsize
+        trace_buffer_size = segy_file.spec.trace.dtype.itemsize
+        for trc_idx in range(segy_file.num_traces):
+            start = trace_offset + trc_idx * trace_buffer_size + header_buffer_size
+            stop = start + sample_buffer_size
+            expected_bytes += segy_file.fs.read_bytes(segy_file.url, start, stop)
+        assert actual_bytes == expected_bytes, "Raw bytes do not match expected."
 
     @pytest.mark.parametrize("standard", [SegyStandard.REV0, SegyStandard.REV1])
     @pytest.mark.parametrize("endianness", [Endianness.BIG, Endianness.LITTLE])
@@ -305,6 +343,23 @@ class TestSegyFile:
         traces = segy_file.trace[index]
         assert_array_equal(traces.header, test_config.expected_headers[index])
         assert_array_almost_equal(traces.sample, test_config.expected_samples[index])
+
+        # Test raw access reusing the complex random access with duplicates
+        index = segy_file.trace.normalize_and_validate_query(index)
+        buffer = segy_file.trace.fetch(index, raw=True)
+        trace_buffer_size = segy_file.spec.trace.dtype.itemsize
+        assert buffer.nbytes == trace_buffer_size * len(index)
+        assert buffer.dtype == np.dtype((np.void, trace_buffer_size))
+        assert buffer.shape == index.shape
+
+        # Test raw access bytes
+        actual_bytes = buffer.tobytes()
+        expected_bytes = b""
+        for trc_idx in index:
+            start = segy_file.spec.trace.offset + trc_idx * trace_buffer_size
+            stop = start + trace_buffer_size
+            expected_bytes += segy_file.fs.read_bytes(segy_file.url, start, stop)
+        assert actual_bytes == expected_bytes, "Raw bytes do not match expected."
 
 
 class TestSegyFileExceptions:

--- a/tests/test_segy_file.py
+++ b/tests/test_segy_file.py
@@ -256,7 +256,6 @@ class TestSegyFile:
         actual_bytes = buffer.tobytes()
         expected_bytes = b""
         trace_offset = segy_file.spec.trace.offset
-        header_buffer_size = segy_file.spec.trace.header.dtype.itemsize
         trace_buffer_size = segy_file.spec.trace.dtype.itemsize
         for trc_idx in range(segy_file.num_traces):
             start = trace_offset + trc_idx * trace_buffer_size


### PR DESCRIPTION
This:

```python
slice_ = slice(0, n_traces)

idx = file.trace.normalize_and_validate_query(slice_)  # this is 1st component of file.traces.__getitem__
raw_arr = file.trace.fetch(idx, raw=True)  # this is 2nd component of file.traces.__getitem__

# Next lines are the 3rd and final component of file.traces.__getitem__
raw_arr_view = raw_arr.view(file.spec.trace.dtype)  # view as defined dtype
raw_to_parsed = file.accessors.trace_decode_pipeline.apply(raw_arr_view.copy())  # copy here bc it normally is inplace
```

should now be equal:
```python
file.traces[slice_]
```

The copy on the first example is there for comparing values because normally trace decode pipeline modifies the array in place.