### PR TITLE
Encode ibm32 header fields on write

### DIFF
--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -21,11 +21,11 @@ from segy.standards.codes import DataSampleFormatCode
 from segy.standards.codes import SegyEndianCode
 from segy.transforms import TransformFactory
 from segy.transforms import TransformPipeline
+from segy.transforms import _modify_dtype_field
 
 if TYPE_CHECKING:
     from typing import Any
 
-    from numpy.typing import DTypeLike
     from numpy.typing import NDArray
 
     from segy.schema import HeaderSpec
@@ -73,29 +73,6 @@ def get_default_text(spec: SegySpec) -> str:
 
     text_lines = [line.ljust(80) for line in text_lines]
     return "\n".join(text_lines)
-
-
-def _retype_struct_fields(
-    dtype: np.dtype[np.void], names: set[str], new_format: DTypeLike
-) -> np.dtype[np.void]:
-    """Return a copy of struct `dtype` with the given field `names` set to `new_format`."""
-    field_names = dtype.names
-    fields = dtype.fields
-    if field_names is None or fields is None:
-        msg = "Expected a structured dtype with named fields."
-        raise ValueError(msg)
-
-    new_type = np.dtype(new_format)
-    return np.dtype(
-        {
-            "names": list(field_names),
-            "formats": [
-                new_type if name in names else fields[name][0] for name in field_names
-            ],
-            "offsets": [fields[name][1] for name in field_names],
-            "itemsize": dtype.itemsize,
-        }
-    )
 
 
 def _ibm32_field_names(header_spec: HeaderSpec) -> set[str]:
@@ -226,9 +203,8 @@ class SegyFactory:
 
         # Expose ibm32 fields as float32 so callers fill real floats that
         # create_traces IBM-encodes (symmetric with the read-side decode).
-        ibm_fields = _ibm32_field_names(trace_header_spec)
-        if ibm_fields:
-            dtype = _retype_struct_fields(dtype, ibm_fields, "float32")
+        for name in _ibm32_field_names(trace_header_spec):
+            dtype = _modify_dtype_field(dtype, name, np.dtype("float32"))
 
         header_template = HeaderArray(np.zeros(shape=size, dtype=dtype))
 

--- a/src/segy/factory.py
+++ b/src/segy/factory.py
@@ -25,8 +25,10 @@ from segy.transforms import TransformPipeline
 if TYPE_CHECKING:
     from typing import Any
 
+    from numpy.typing import DTypeLike
     from numpy.typing import NDArray
 
+    from segy.schema import HeaderSpec
     from segy.schema import SegySpec
 
 
@@ -71,6 +73,34 @@ def get_default_text(spec: SegySpec) -> str:
 
     text_lines = [line.ljust(80) for line in text_lines]
     return "\n".join(text_lines)
+
+
+def _retype_struct_fields(
+    dtype: np.dtype[np.void], names: set[str], new_format: DTypeLike
+) -> np.dtype[np.void]:
+    """Return a copy of struct `dtype` with the given field `names` set to `new_format`."""
+    field_names = dtype.names
+    fields = dtype.fields
+    if field_names is None or fields is None:
+        msg = "Expected a structured dtype with named fields."
+        raise ValueError(msg)
+
+    new_type = np.dtype(new_format)
+    return np.dtype(
+        {
+            "names": list(field_names),
+            "formats": [
+                new_type if name in names else fields[name][0] for name in field_names
+            ],
+            "offsets": [fields[name][1] for name in field_names],
+            "itemsize": dtype.itemsize,
+        }
+    )
+
+
+def _ibm32_field_names(header_spec: HeaderSpec) -> set[str]:
+    """Names of header fields declared as ibm32."""
+    return {f.name for f in header_spec.fields if f.format == ScalarType.IBM32}
 
 
 class SegyFactory:
@@ -194,6 +224,12 @@ class SegyFactory:
         trace_header_spec = self.spec.trace.header
         dtype = trace_header_spec.dtype.newbyteorder("=")
 
+        # Expose ibm32 fields as float32 so callers fill real floats that
+        # create_traces IBM-encodes (symmetric with the read-side decode).
+        ibm_fields = _ibm32_field_names(trace_header_spec)
+        if ibm_fields:
+            dtype = _retype_struct_fields(dtype, ibm_fields, "float32")
+
         header_template = HeaderArray(np.zeros(shape=size, dtype=dtype))
 
         # 'names' assumed not None by data structure (type ignores).
@@ -274,6 +310,21 @@ class SegyFactory:
 
         target_endian = trace_spec.endianness
         target_format = trace_spec.data.format
+
+        # IBM-encode ibm32 header fields, mirroring the read-side decode in
+        # TraceAccessor. Runs before the byte-swap so values are encoded in
+        # native order and then swapped like every other header field.
+        header_ibm_keys = [
+            field.name
+            for field in trace_spec.header.fields
+            if field.format == ScalarType.IBM32
+        ]
+        if header_ibm_keys:
+            logger.debug("Added IBM float conversion for header fields.")
+            header_ibm_float = TransformFactory.create(
+                "ibm_float", "to_ibm", keys=header_ibm_keys
+            )
+            header_pipeline.add_transform(header_ibm_float)
 
         if target_endian == Endianness.BIG:
             logger.debug("Added big endian conversion before serialization.")

--- a/tests/test_segy_factory.py
+++ b/tests/test_segy_factory.py
@@ -11,6 +11,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from segy.factory import SegyFactory
+from segy.ibm import ibm2ieee
 from segy.ibm import ieee2ibm
 from segy.schema import Endianness
 from segy.schema import HeaderField
@@ -262,6 +263,75 @@ class TestSegyFactoryTraces:
             expected_traces = expected_traces.view(expected_dtype)
 
         assert trace_bytes == expected_traces.tobytes()
+
+
+@pytest.mark.parametrize("endianness", [Endianness.BIG, Endianness.LITTLE])
+@pytest.mark.parametrize("num_traces", [1, 42])
+class TestSegyFactoryIbmHeader:
+    """ibm32 *header* fields must be IBM-encoded on write.
+
+    The read path (TraceAccessor) IBM-decodes ibm32 header fields, so the
+    write path must IBM-encode them symmetrically; otherwise an ibm32 header
+    round-trips to a different value than it was written with.
+    """
+
+    @staticmethod
+    def _make_factory(endianness: Endianness) -> SegyFactory:
+        spec = minimal_segy
+        spec.endianness = endianness
+        spec.segy_standard = SegyStandard.REV1
+        spec.trace.header.item_size = 32
+        spec.trace.header.fields = [
+            HeaderField(name="ibm_field", format=ScalarType.IBM32, byte=5),
+            HeaderField(name="int_field", format=ScalarType.INT32, byte=9),
+        ]
+        return SegyFactory(spec, sample_interval=2000, samples_per_trace=4)
+
+    def test_ibm32_header_serialize(
+        self, endianness: Endianness, num_traces: int
+    ) -> None:
+        """On-disk ibm32 header bytes equal the IBM-encoding of the value."""
+        factory = self._make_factory(endianness)
+        rng = np.random.default_rng(0)
+        values = np.float32(100 * rng.random(size=num_traces))
+        int_values = rng.integers(-1000, 1000, dtype="int32", size=num_traces)
+
+        headers = factory.create_trace_header_template(num_traces)
+        headers["ibm_field"] = values
+        headers["int_field"] = int_values
+        samples = factory.create_trace_sample_template(num_traces)
+
+        trace_bytes = factory.create_traces(headers, samples)
+
+        trace_native = factory.spec.trace.dtype.newbyteorder("=")
+        traces = np.frombuffer(trace_bytes, dtype=factory.spec.trace.dtype)
+        traces = traces.astype(trace_native)
+
+        assert_array_equal(traces["header"]["ibm_field"], ieee2ibm(values))
+        assert_array_equal(traces["header"]["int_field"], int_values)
+
+    def test_ibm32_header_round_trip(
+        self, endianness: Endianness, num_traces: int
+    ) -> None:
+        """Writing then decoding an ibm32 header returns the original value."""
+        factory = self._make_factory(endianness)
+        rng = np.random.default_rng(1)
+        # Integer-valued floats are exact in both IBM32 and IEEE float32, so the
+        # round trip is lossless and can be compared exactly.
+        values = rng.integers(-10000, 10000, size=num_traces).astype("float32")
+
+        headers = factory.create_trace_header_template(num_traces)
+        headers["ibm_field"] = values
+        samples = factory.create_trace_sample_template(num_traces)
+
+        trace_bytes = factory.create_traces(headers, samples)
+
+        trace_native = factory.spec.trace.dtype.newbyteorder("=")
+        traces = np.frombuffer(trace_bytes, dtype=factory.spec.trace.dtype)
+        traces = traces.astype(trace_native)
+        decoded = ibm2ieee(traces["header"]["ibm_field"].astype("uint32"))
+
+        assert_array_equal(decoded, values)
 
 
 class TestSegyFactoryExceptions:


### PR DESCRIPTION
## Problem

`SegyFactory.create_traces` does not IBM-encode `ibm32` header fields, even though `TraceAccessor` IBM-decodes them on read. The write path is therefore asymmetric with the read path: an `ibm32` header written by the factory is stored as a raw integer, and reading it back through the IBM decode yields garbage.

We hit this in a production MDIO->SEG-Y cut: an `ibm32` header (azimuth) came out of the cut as a plain integer, which QC then flagged because the value no longer matched the source.

## Fix

- `create_traces`: add a keyed `to_ibm` transform to the header pipeline, placed before the byte-swap. This is the exact inverse of the read path (`byte_swap` then `to_ieee`) and mirrors the data pipeline's existing `ibm32` handling.
- `create_trace_header_template`: expose `ibm32` fields as `float32` instead of `uint32`, so callers fill real float values that then get encoded. This matches what the reader returns for `ibm32` headers and what `create_trace_sample_template` already does for `ibm32` samples.

The on-disk format is unchanged (4 bytes, IBM-encoded, big-endian); only the in-memory template dtype changes.

## Open question

The `create_traces` encode change fixes the bug on its own, because the reader already hands callers a `float32` array.

The `create_trace_header_template` -> `float32` change is the consistency/usability part, and it's the only piece that changes a public dtype. Happy to drop it and keep the PR to just the encode if you'd rather avoid the template dtype change. Let me know which you prefer.

## Tests

- New `TestSegyFactoryIbmHeader` (big/little x 1/42 traces): on-disk bytes equal `ieee2ibm(value)`, plus a lossless round-trip.
- Full suite: 289 passed. `mypy` and `ruff` clean.
